### PR TITLE
common: Use toolchains to enforce which Java version is used to build

### DIFF
--- a/indra-common/src/main/kotlin/net/kyori/indra/Indra.kt
+++ b/indra-common/src/main/kotlin/net/kyori/indra/Indra.kt
@@ -51,14 +51,28 @@ fun versionString(version: JavaVersion): String = when(version) {
   JavaVersion.VERSION_1_10 -> "10"
   else -> version.toString()
 }
+fun versionString(version: Int): String = when(version) {
+  in 1..8 -> "1.$version"
+  else -> version.toString()
+}
 
 /**
  * Link to the API documentation for a specific java version.
  */
+@Deprecated("Use the variant with an integer version instead", replaceWith = ReplaceWith("jdkApiDocs(versionNumber(version))"))
 fun jdkApiDocs(version: JavaVersion): String = if(version.isJava11Compatible) {
   "https://docs.oracle.com/en/java/javase/${version.majorVersion}/docs/api"
 } else {
   "https://docs.oracle.com/javase/${version.majorVersion}/docs/api"
+}
+
+/**
+ * Link to the API documentation for a specific java version.
+ */
+fun jdkApiDocs(javaVersion: Int): String = if(javaVersion >= 11) {
+  "https://docs.oracle.com/en/java/javase/$javaVersion/docs/api"
+} else {
+  "https://docs.oracle.com/javase/$javaVersion/docs/api"
 }
 
 fun grgit(project: Project): Grgit? {

--- a/indra-common/src/main/kotlin/net/kyori/indra/JavaToolchainVersions.kt
+++ b/indra-common/src/main/kotlin/net/kyori/indra/JavaToolchainVersions.kt
@@ -1,0 +1,105 @@
+/*
+ * This file is part of indra, licensed under the MIT License.
+ *
+ * Copyright (c) 2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.indra
+
+import org.gradle.api.JavaVersion
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.api.provider.SetProperty
+import org.gradle.kotlin.dsl.property
+import org.gradle.kotlin.dsl.setProperty
+import javax.inject.Inject
+import kotlin.math.max
+
+/**
+ * Options configuring the toolchain versioning
+ */
+open class JavaToolchainVersions @Inject constructor(objects: ObjectFactory, providers: ProviderFactory) {
+
+  /**
+   * The target Java version to compile for.
+   *
+   * Default: 8
+   */
+  val target: Property<Int> = objects.property(Int::class).convention(8)
+
+  /**
+   * The minimum toolchain version to use when building.
+   *
+   * Default: 11
+   */
+  val minimumToolchain: Property<Int> = objects.property(Int::class).convention(11)
+
+  /**
+   * Whether to strictly apply toolchain versions.
+   *
+   * If this is set to false, java toolchains will only be overridden for
+   * the Gradle JVM's version is less than the target version,
+   * and cross-version testing will not be performed.
+   */
+  val strictVersions: Property<Boolean> = objects.property<Boolean>()
+    .convention(
+      providers.gradleProperty("strictMultireleaseVersions")
+        .orElse(providers.environmentVariable("CI")) // set by GH Actions and Travis
+        .map(String::toBoolean)
+        .orElse(false)
+    )
+
+  /**
+   * Toolchains that should be used to execute tests
+   */
+  val testWith: SetProperty<Int> = objects.setProperty(Int::class)
+
+  /**
+   * If preview features should be enabled. This will be applied to all compile and JavaExec tasks
+   */
+  val enablePreviewFeatures: Property<Boolean> = objects.property(Boolean::class).convention(false)
+
+  /** The version that should be used to run compile tasks, taking into account strict version and current JVM */
+  internal val actualVersion: Provider<Int> = this.strictVersions.map { strict ->
+    val running = versionNumber(JavaVersion.current())
+    target.finalizeValue()
+    minimumToolchain.finalizeValue()
+    val minimum = max(minimumToolchain.get(), target.get()) // If target > minimum toolchain, the target is our new minimum
+    if(strict || running < minimum) {
+      minimum
+    } else {
+      running
+    }
+  }
+
+  init {
+    testWith.add(target)
+  }
+
+  /**
+   * Add versions that should be tested with, when strict versions are enabled.
+   */
+  fun testWith(vararg testVersions: Int) {
+    testWith.addAll(testVersions.toList())
+  }
+
+}


### PR DESCRIPTION
This creates a new section of the indra extension to configure versioning properties, which include:

- `target`: The version to target, used for `--release` flag (as well as legacy `source` and `target` options)
- `minimumToolchain`: The minimum java version to build with -- by default Java 11.
- `testWith`: A list of Java versions to run tests on
- `strictVersions`: Whether to use exact versions -- defaults to false, unless either the gradle property `strictMultireleaseVersions` is set to `true`, or the `CI` environment variable is set (done automatically by GH actions).
- `enableJavaPreviewFeatures` has been moved in here -- should probably be renamed to remove the redundant `Java` from the field name.

The only current issue is in the configuration of JavaCompile tasks -- we can only specify the `release` flag if the compiler is at least Java 9, but we can't actually resolve the toolchain at configuration time, so this will prevent projects from building using the JDK8 compiler. 