### PR TITLE
net.kyori.indra.publishing.gradle-plugin

### DIFF
--- a/indra-common/src/main/kotlin/net/kyori/indra/AbstractIndraPublishingPlugin.kt
+++ b/indra-common/src/main/kotlin/net/kyori/indra/AbstractIndraPublishingPlugin.kt
@@ -1,0 +1,168 @@
+/*
+ * This file is part of indra, licensed under the MIT License.
+ *
+ * Copyright (c) 2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.indra
+
+import net.kyori.indra.task.RequireClean
+import org.ajoberstar.grgit.gradle.GrgitPlugin
+import org.gradle.api.Action
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
+import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
+import org.gradle.api.publish.maven.tasks.PublishToMavenLocal
+import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.credentials
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.register
+import org.gradle.kotlin.dsl.withType
+import org.gradle.plugins.signing.Sign
+import org.gradle.plugins.signing.SigningExtension
+import org.gradle.plugins.signing.SigningPlugin
+
+/**
+ * Common behaviour between 'standard' and Gradle Plugin publishing.
+ */
+abstract class AbstractIndraPublishingPlugin : Plugin<Project> {
+  final override fun apply(target: Project) {
+    with(target) {
+      val extension = extension(project)
+
+      plugins.apply(MavenPublishPlugin::class)
+      plugins.apply(SigningPlugin::class)
+      plugins.apply(GrgitPlugin::class)
+
+      // Inherit options from root project
+      if(this != rootProject) {
+        group = rootProject.group
+        version = rootProject.version
+        description = rootProject.description
+      }
+
+      val descriptionProvider = project.provider { project.description }
+      configurePublications(extensions.getByType(PublishingExtension::class), Action {
+        it.pom.apply {
+          name.set(project.name)
+          description.set(descriptionProvider)
+          url.set(extension.scm.map(net.kyori.indra.data.SCM::url))
+
+          ciManagement { ci ->
+            ci.system.set(extension.ci.map(net.kyori.indra.data.ContinuousIntegration::system))
+            ci.url.set(extension.ci.map(net.kyori.indra.data.ContinuousIntegration::url))
+          }
+
+          issueManagement { issues ->
+            issues.system.set(extension.issues.map(net.kyori.indra.data.Issues::system))
+            issues.url.set(extension.issues.map(net.kyori.indra.data.Issues::url))
+          }
+
+          licenses { licenses ->
+            licenses.license { license ->
+              license.name.set(extension.license.map(net.kyori.indra.data.License::name))
+              license.url.set(extension.license.map(net.kyori.indra.data.License::url))
+            }
+          }
+
+          scm { scm ->
+            scm.connection.set(extension.scm.map(net.kyori.indra.data.SCM::connection))
+            scm.developerConnection.set(extension.scm.map(net.kyori.indra.data.SCM::developerConnection))
+            scm.url.set(extension.scm.map(net.kyori.indra.data.SCM::url))
+          }
+        }
+      })
+
+      extensions.configure<SigningExtension> {
+        sign(extensions.getByType<PublishingExtension>().publications)
+        useGpgCmd()
+      }
+
+      tasks.withType(Sign::class).configureEach {
+        it.onlyIf {
+          project.hasProperty("forceSign") || isRelease(project)
+        }
+      }
+
+      val requireClean = tasks.register(RequireClean.NAME, RequireClean::class)
+      tasks.withType(AbstractPublishToMaven::class).configureEach {
+        if(it !is PublishToMavenLocal) {
+          it.dependsOn(requireClean)
+        }
+      }
+
+      afterEvaluate {
+        extensions.getByType(PublishingExtension::class).apply {
+          applyPublishingActions(this, extension.publishingActions)
+
+          extension.repositories.all { // will be applied to repositories as they're added
+            val username = "${it.id}Username"
+            val password = "${it.id}Password"
+            if(((it.releases && isRelease(project))
+                || (it.snapshots && isSnapshot(project)))
+              && project.hasProperty(username)
+              && project.hasProperty(password)) {
+              repositories.maven { repository ->
+                repository.name = it.id
+                repository.url = it.url
+                // ${id}Username + ${id}Password properties
+                repository.credentials(org.gradle.api.artifacts.repositories.PasswordCredentials::class)
+              }
+            }
+          }
+        }
+      }
+      extraApplySteps(target)
+    }
+  }
+
+  /**
+   * Add any extra steps sub-plugins might want to perform on application
+   */
+  open fun extraApplySteps(target: Project) { }
+
+  /**
+   * Apply publishing actions to all publications targeted.
+   */
+  abstract fun applyPublishingActions(publishing: PublishingExtension, actions: Set<Action<MavenPublication>>)
+
+  /**
+   * Configure and/or create publications, applying the provided common configuration action.
+   */
+  abstract fun configurePublications(publishing: PublishingExtension, configuration: Action<MavenPublication>)
+}
+
+fun isSnapshot(project: Project) = project.version.toString().contains("-SNAPSHOT")
+
+/**
+ * Verify that this project is checked out to a release version, meaning that:
+ *
+ * - The version does not contain SNAPSHOT
+ * - The project is managed within a Git repository
+ * - the current head commit is tagged
+ */
+fun isRelease(project: Project): Boolean {
+  val tag = net.kyori.indra.util.headTag(project)
+  return (tag != null || net.kyori.indra.util.grgit(project) == null) && !isSnapshot(project)
+}

--- a/indra-publishing-gradle-plugin/build.gradle.kts
+++ b/indra-publishing-gradle-plugin/build.gradle.kts
@@ -1,0 +1,13 @@
+import net.kyori.indra.self.declarePlugin
+
+dependencies {
+  implementation(project(":indra-common"))
+}
+
+declarePlugin(
+  id = "indra.publishing.gradle-plugin",
+  mainClass = "gradle.GradlePluginPublishingPlugin",
+  displayName = "Indra Gradle Plugin Publishing",
+  description = "Reasonable settings for Gradle plugin publishing",
+  tags = listOf("publishing", "gradle-plugin", "boilerplate")
+)

--- a/indra-publishing-gradle-plugin/build.gradle.kts
+++ b/indra-publishing-gradle-plugin/build.gradle.kts
@@ -2,6 +2,7 @@ import net.kyori.indra.self.declarePlugin
 
 dependencies {
   implementation(project(":indra-common"))
+  implementation("com.gradle.publish:plugin-publish-plugin:0.12.0")
 }
 
 declarePlugin(

--- a/indra-publishing-gradle-plugin/src/main/kotlin/net/kyori/indra/gradle/GradlePluginPublishingPlugin.kt
+++ b/indra-publishing-gradle-plugin/src/main/kotlin/net/kyori/indra/gradle/GradlePluginPublishingPlugin.kt
@@ -1,0 +1,34 @@
+/*
+ * This file is part of indra, licensed under the MIT License.
+ *
+ * Copyright (c) 2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.indra.gradle
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class GradlePluginPublishingPlugin : Plugin<Project> {
+  override fun apply(project: Project) {
+    with(project) {
+    }
+  }
+}

--- a/indra-publishing-gradle-plugin/src/main/kotlin/net/kyori/indra/gradle/IndraPluginPublishingExtension.kt
+++ b/indra-publishing-gradle-plugin/src/main/kotlin/net/kyori/indra/gradle/IndraPluginPublishingExtension.kt
@@ -1,0 +1,73 @@
+/*
+ * This file is part of indra, licensed under the MIT License.
+ *
+ * Copyright (c) 2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.indra.gradle
+
+import com.gradle.publish.PluginBundleExtension
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.kotlin.dsl.property
+import org.gradle.plugin.devel.GradlePluginDevelopmentExtension
+import javax.inject.Inject
+
+open class IndraPluginPublishingExtension @Inject constructor(
+  objects: ObjectFactory,
+  private val publishingExtension: GradlePluginDevelopmentExtension,
+  private val pluginBundleExtension: PluginBundleExtension
+) {
+
+  val pluginIdBase: Property<String> = objects.property(String::class)
+
+
+  /**
+   * Register a plugin to have marker validated, and to be deployed to the Gradle Plugin Portal.
+   *
+   * The id is relative to [pluginIdBase], which is by default the project's group id. Main class is absolute.
+   *
+   * If no tags are set on the global plugin bundle, then the first provided set of tags will be applied.
+   */
+  fun plugin(id: String, mainClass: String, displayName: String, description: String? = null, tags: List<String> = listOf()) {
+    val qualifiedId = "${pluginIdBase.get()}.$id"
+    publishingExtension.plugins.create(id) {
+      it.id = qualifiedId
+      it.implementationClass = mainClass
+    }
+
+    pluginBundleExtension.apply {
+      plugins.maybeCreate(id).apply {
+        this.id = qualifiedId
+        this.displayName = displayName
+        if(tags.isNotEmpty()) {
+          this.tags = tags
+        }
+        if(description != null) {
+          this.description = description
+        }
+      }
+
+      if(tags.isEmpty()) {
+        this.tags = tags
+      }
+    }
+  }
+}

--- a/indra-publishing-gradle-plugin/src/test/kotlin/net/kyori/indra/gradle/GradlePluginPublishingPluginTest.kt
+++ b/indra-publishing-gradle-plugin/src/test/kotlin/net/kyori/indra/gradle/GradlePluginPublishingPluginTest.kt
@@ -1,0 +1,36 @@
+/*
+ * This file is part of indra, licensed under the MIT License.
+ *
+ * Copyright (c) 2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.indra.gradle
+
+import org.gradle.testfixtures.ProjectBuilder
+import kotlin.test.Test
+
+class GradlePluginPublishingPluginTest {
+  @Test
+  fun testEmptyBuild() {
+    val project = ProjectBuilder.builder().build()
+
+    project.pluginManager.apply("net.kyori.indra.publishing.gradle-plugin")
+  }
+}

--- a/indra-publishing-gradle-plugin/src/test/kotlin/net/kyori/indra/gradle/GradlePluginPublishingPluginTest.kt
+++ b/indra-publishing-gradle-plugin/src/test/kotlin/net/kyori/indra/gradle/GradlePluginPublishingPluginTest.kt
@@ -25,6 +25,8 @@ package net.kyori.indra.gradle
 
 import org.gradle.testfixtures.ProjectBuilder
 import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 class GradlePluginPublishingPluginTest {
   @Test
@@ -32,5 +34,12 @@ class GradlePluginPublishingPluginTest {
     val project = ProjectBuilder.builder().build()
 
     project.pluginManager.apply("net.kyori.indra.publishing.gradle-plugin")
+
+    assertNull(project.extensions.findByName("indraPluginPublishing"))
+
+    project.pluginManager.apply("java-gradle-plugin")
+    project.pluginManager.apply("com.gradle.plugin-publish")
+
+    assertNotNull(project.extensions.findByName("indraPluginPublishing"))
   }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,7 @@ rootProject.name = "indra"
 listOf(
   "indra-common",
   "indra-publishing-bintray",
+  "indra-publishing-gradle-plugin",
   "indra-publishing-sonatype"
 ).forEach {
   include(it)


### PR DESCRIPTION
This allows using Indra's publishing logic in a way that is compatible with the oddities of Gradle plugin publishing, plus extracts the plugin declaration helper used in Indra itself to be usable in other projects.