### PR TITLE
multirelease: Hook Javadoc into multirelease system

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,15 @@ subprojects {
       website("https://github.com/KyoriPowered/indra/wiki")
     }
   }
+  
+  if ('true'.equals(project.findProperty("skipFunctionalTests"))) {
+      tasks.named('test') {
+          useJUnitPlatform {
+              excludeTags 'functional'
+          }
+      }
+  }
+    
 
   license {
     exclude { it.file.absolutePath.startsWith(project.file('src/test/resources').absolutePath) }

--- a/indra-common/src/main/java/net/kyori/indra/internal/multirelease/IndraMultireleasePlugin.java
+++ b/indra-common/src/main/java/net/kyori/indra/internal/multirelease/IndraMultireleasePlugin.java
@@ -48,8 +48,10 @@ import org.gradle.api.GradleException;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.SourceDirectorySet;
@@ -65,13 +67,16 @@ import org.gradle.api.tasks.Copy;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.SourceSetOutput;
+import org.gradle.api.tasks.TaskCollection;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
 import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.api.tasks.compile.AbstractCompile;
 import org.gradle.api.tasks.compile.JavaCompile;
+import org.gradle.api.tasks.javadoc.Javadoc;
 import org.gradle.api.tasks.testing.Test;
+import org.gradle.external.javadoc.StandardJavadocDocletOptions;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.gradle.jvm.toolchain.JavaToolchainService;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
@@ -144,10 +149,21 @@ public class IndraMultireleasePlugin implements ProjectPlugin {
   }
 
   private void configureLanguages(final Project project, final SourceSet set, final Provider<Integer> toolchainVersion, final Provider<Integer> targetVersion) {
+    this.configureLanguages(project, set, toolchainVersion, targetVersion, toolchainVersion, targetVersion);
+  }
+
+  private void configureLanguages(
+    final Project project,
+    final SourceSet set,
+    final Provider<Integer> compileToolchainVersion,
+    final Provider<Integer> compileTargetVersion,
+    final Provider<Integer> docsToolchainVersion,
+    final Provider<Integer> docsTargetVersion
+  ) {
     for (final LanguageSupport lang : this.languageSupports) {
       lang.registerApplyCallback(project, p -> {
-        lang.configureCompileTasks(p, set, toolchainVersion, targetVersion);
-        lang.configureDocTasks(p, set, toolchainVersion, targetVersion);
+        lang.configureCompileTasks(p, set, compileToolchainVersion, compileTargetVersion);
+        lang.configureDocTasks(p, set, docsToolchainVersion, docsTargetVersion);
       });
     }
   }
@@ -162,7 +178,29 @@ public class IndraMultireleasePlugin implements ProjectPlugin {
       }
       final IndraExtension indra = Indra.extension(project.getExtensions());
       final MultireleaseSourceSet multireleaseExtension = parent.getExtensions().create(MultireleaseSourceSet.class, "multirelease", MultireleaseSourceSetImpl.class, project.getObjects());
-      this.configureLanguages(project, parent, indra.javaVersions().actualVersion(), indra.javaVersions().target());
+
+      // Configure multirelease Javadoc, if it is enabled in the extension.
+      // The way we handle this is a touch hacky, to handle the dependency chains, but it should work
+      // If modular javadoc is not enabled, we pass an empty alternates list into calculations rather than the actual list
+      final Provider<Set<Integer>> alternateVersions = project.getProviders().provider(() -> multireleaseExtension.alternateVersions()).zip(multireleaseExtension.applyToJavadoc(), (alternates, useAlts) -> {
+        return useAlts ? alternates : Collections.emptySet();
+      });
+      final Provider<Integer> docsTargetVersion = indra.javaVersions().target().zip(alternateVersions, (base, alternates) -> {
+        int actual = base;
+        for (final int version : alternates) {
+          actual = Math.max(version, actual);
+        }
+        return actual;
+      });
+      final Provider<Integer> docsRuntimeVersion = indra.javaVersions().actualVersion().zip(alternateVersions, (base, alternates) -> {
+        int actual = base;
+        for (final int version : alternates) {
+          actual = Math.max(version, actual);
+        }
+        return actual;
+      });
+
+      this.configureLanguages(project, parent, indra.javaVersions().actualVersion(), indra.javaVersions().target(), docsRuntimeVersion, docsTargetVersion);
 
       multireleaseExtension.alternateVersions().whenObjectAdded(version -> {
         // Ideally we'd be able to initialize the source set here, but for some reason gradle won't let us do that...
@@ -374,6 +412,32 @@ public class IndraMultireleasePlugin implements ProjectPlugin {
       }
     });
 
+    // Configure modular javadoc
+    final Property<Boolean> modularJavadoc = main.applyToJavadoc();
+    final ConfigurableFileCollection modulePatch = project.getObjects().fileCollection();
+    final TaskCollection<Task> javadocTasks = tasks.matching(t -> t.getName().equals(mainSet.getJavadocTaskName()) && t instanceof Javadoc);
+    main.configureVariants(details -> {
+      javadocTasks.configureEach(t -> {
+        // Add multirelease source directories and classpath
+        final Javadoc javadocTask = (Javadoc) t;
+        if (modularJavadoc.get()) {
+          javadocTask.source(details.variant().getAllJava());
+          javadocTask.setClasspath(javadocTask.getClasspath().plus(details.variant().getOutput()));
+        }
+      });
+
+      modulePatch.from(details.variant().getAllJava().getSourceDirectories());
+    });
+
+    // Javadoc configuration  that only affects the task one
+    javadocTasks.configureEach(t -> {
+      final Property<String> moduleName = main.moduleName();
+      t.getInputs().property("moduleName", moduleName)
+        .optional(true);
+      t.getInputs().property("isMultireleaseModular", modularJavadoc);
+      t.doFirst(new AddModulePatchAction(modularJavadoc, moduleName, modulePatch));
+    });
+
     // Add test variants to the indra-created versioned test tasks
     // Also add to the primary test task depending on the active JVM version (when strict multirelease variants aren't present)
     final MultireleaseSourceSet test = MultireleaseSourceSet.from(sourceSets.getByName(SourceSet.TEST_SOURCE_SET_NAME));
@@ -408,6 +472,27 @@ public class IndraMultireleasePlugin implements ProjectPlugin {
         testTask.dependsOn(variantCompile);
       });
     });
+  }
+
+  static final class AddModulePatchAction implements Action<Task> {
+    private final Property<Boolean> modularJavadoc;
+    private final Property<String> moduleName;
+    private final FileCollection modulePatchPath;
+
+    AddModulePatchAction(final Property<Boolean> modularJavadoc, final Property<String> moduleName, final FileCollection modulePatchPath) {
+      this.modularJavadoc = modularJavadoc;
+      this.moduleName = moduleName;
+      this.modulePatchPath = modulePatchPath;
+    }
+
+    @Override
+    public void execute(final Task task) {
+      final Javadoc javadocTask = (Javadoc) task;
+      if (this.modularJavadoc.get() && this.moduleName.isPresent()) {
+        ((StandardJavadocDocletOptions) javadocTask.getOptions())
+          .addStringOption("-patch-module", this.moduleName.get() + '=' + this.modulePatchPath.getAsPath());
+      }
+    }
   }
 
   private void configureEclipseProjectVersions(final Project project, final EclipseModel model, final IndraExtension indra, final SourceSetContainer sourceSets) {

--- a/indra-common/src/main/java/net/kyori/indra/internal/multirelease/MultireleaseSourceSetImpl.java
+++ b/indra-common/src/main/java/net/kyori/indra/internal/multirelease/MultireleaseSourceSetImpl.java
@@ -43,6 +43,7 @@ class MultireleaseSourceSetImpl implements MultireleaseSourceSet {
 
   private final DomainObjectSet<Integer> alternateVersions;
   private final Property<String> moduleName;
+  private final Property<Boolean> applyToJavadoc;
   final Set<Action<MultireleaseVariantDetails>> alternateConfigurationActions = new HashSet<>();
   final Set<Action<? super CheckModuleExports>> exportValidation = new HashSet<>();
 
@@ -50,6 +51,7 @@ class MultireleaseSourceSetImpl implements MultireleaseSourceSet {
   public MultireleaseSourceSetImpl(final ObjectFactory objects) {
     this.alternateVersions = objects.domainObjectSet(Integer.class);
     this.moduleName = objects.property(String.class);
+    this.applyToJavadoc = objects.property(Boolean.class).convention(false);
   }
 
   @Override
@@ -87,5 +89,10 @@ class MultireleaseSourceSetImpl implements MultireleaseSourceSet {
   @Override
   public void requireAllPackagesExported(final Action<? super CheckModuleExports> action) {
     this.exportValidation.add(action);
+  }
+
+  @Override
+  public Property<Boolean> applyToJavadoc() {
+    return this.applyToJavadoc;
   }
 }

--- a/indra-common/src/main/java/net/kyori/indra/multirelease/MultireleaseSourceSet.java
+++ b/indra-common/src/main/java/net/kyori/indra/multirelease/MultireleaseSourceSet.java
@@ -92,6 +92,7 @@ public interface MultireleaseSourceSet {
    * @since 2.0.0
    */
   void configureVariants(final @NotNull Action<MultireleaseVariantDetails> action);
+
   /**
    * Register a task to validate that all packages in the module this source set defines are exported.
    *
@@ -108,4 +109,25 @@ public interface MultireleaseSourceSet {
    * @since 2.1.0
    */
   void requireAllPackagesExported(final @NotNull Action<? super CheckModuleExports> action);
+  /**
+   * Configure whether multi-release contents are exposed to Javadoc generation.
+   *
+   * <p>This includes adding a module descriptor to Javadoc that may otherwise only be present in multi-release variants.</p>
+   *
+   * @return a property controlling whether Javadoc generation should be multi-release aware
+   * @since 2.1.0
+   */
+  Property<Boolean> applyToJavadoc();
+
+  /**
+   * Configure whether multi-release contents are exposed to Javadoc generation.
+   *
+   * <p>This includes adding a module descriptor to Javadoc that may otherwise only be present in multi-release variants.</p>
+   *
+   * @param applyToJavadoc whether Javadoc generation should be multi-release aware
+   * @since 2.1.0
+   */
+  default void applyToJavadoc(final boolean applyToJavadoc) {
+    this.applyToJavadoc().set(applyToJavadoc);
+  }
 }

--- a/indra-common/src/test/java/net/kyori/indra/IndraPluginFunctionalTest.java
+++ b/indra-common/src/test/java/net/kyori/indra/IndraPluginFunctionalTest.java
@@ -124,8 +124,8 @@ class IndraPluginFunctionalTest {
     ctx.copyInput("subprojects/core/j9/module-info.java", "subprojects/core/src/main/java9/module-info.java");
 
     ctx.copyInput("subprojects/module-consumer/build.gradle");
-    ctx.copyInput("subprojects/module-consumer/ModuleConsumer.java", "subrojects/module-consumer/src/main/java/testproject/consumer/ModuleConsumer.java");
-    ctx.copyInput("subprojects/module-consumer/module-info.java", "subrojects/module-consumer/src/main/java/module-info.java");
+    ctx.copyInput("subprojects/module-consumer/ModuleConsumer.java", "subprojects/module-consumer/src/main/java/testproject/consumer/ModuleConsumer.java");
+    ctx.copyInput("subprojects/module-consumer/module-info.java", "subprojects/module-consumer/src/main/java/module-info.java");
 
     ctx.copyInput("subprojects/multirelease-module-consumer/build.gradle");
     ctx.copyInput("subprojects/multirelease-module-consumer/j8/Main.java", "subprojects/multirelease-module-consumer/src/main/java/testproject/consumer/multirelease/Main.java");

--- a/indra-common/src/test/resources/net/kyori/indra/multiprojectModular/in/subprojects/multirelease-module-consumer/build.gradle
+++ b/indra-common/src/test/resources/net/kyori/indra/multiprojectModular/in/subprojects/multirelease-module-consumer/build.gradle
@@ -13,4 +13,5 @@ dependencies {
 sourceSets.main.multirelease {
   moduleName 'testproject.consumer.multirelease'
   alternateVersions 9, 11
+  applyToJavadoc true
 }


### PR DESCRIPTION
Closes GH-34

Implementing this logic begins pushing against the current divide between 'standard' and 'multirelease' version handling. Before this is merged, #47 should probably happen. That will allow us to handle versioning with less fighting between the two models.