### PR TITLE
common: Add tasks for module descriptor validation

### DIFF
--- a/indra-common/build.gradle
+++ b/indra-common/build.gradle
@@ -21,6 +21,7 @@ dependencies {
   compileOnlyApi "org.jetbrains:annotations:23.0.0"
   api project(":indra-git")
   implementation "gradle.plugin.org.cadixdev.gradle:licenser:0.6.1"
+  implementation "org.ow2.asm:asm:9.2"
   api "net.kyori:mammoth:$mammothVersion"
   testImplementation project(":indra-testlib")
 }

--- a/indra-common/src/main/java/net/kyori/indra/internal/multirelease/MultireleaseSourceSetImpl.java
+++ b/indra-common/src/main/java/net/kyori/indra/internal/multirelease/MultireleaseSourceSetImpl.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import javax.inject.Inject;
 import net.kyori.indra.multirelease.MultireleaseSourceSet;
 import net.kyori.indra.multirelease.MultireleaseVariantDetails;
+import net.kyori.indra.task.CheckModuleExports;
 import org.gradle.api.Action;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.model.ObjectFactory;
@@ -43,6 +44,7 @@ class MultireleaseSourceSetImpl implements MultireleaseSourceSet {
   private final DomainObjectSet<Integer> alternateVersions;
   private final Property<String> moduleName;
   final Set<Action<MultireleaseVariantDetails>> alternateConfigurationActions = new HashSet<>();
+  final Set<Action<? super CheckModuleExports>> exportValidation = new HashSet<>();
 
   @Inject
   public MultireleaseSourceSetImpl(final ObjectFactory objects) {
@@ -75,5 +77,15 @@ class MultireleaseSourceSetImpl implements MultireleaseSourceSet {
   @Override
   public void configureVariants(final @NotNull Action<MultireleaseVariantDetails> action) {
     this.alternateConfigurationActions.add(requireNonNull(action, "action"));
+  }
+
+  @Override
+  public void requireAllPackagesExported() {
+    this.requireAllPackagesExported(task -> {});
+  }
+
+  @Override
+  public void requireAllPackagesExported(final Action<? super CheckModuleExports> action) {
+    this.exportValidation.add(action);
   }
 }

--- a/indra-common/src/main/java/net/kyori/indra/multirelease/MultireleaseSourceSet.java
+++ b/indra-common/src/main/java/net/kyori/indra/multirelease/MultireleaseSourceSet.java
@@ -23,6 +23,7 @@
  */
 package net.kyori.indra.multirelease;
 
+import net.kyori.indra.task.CheckModuleExports;
 import org.gradle.api.Action;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.provider.Property;
@@ -91,4 +92,20 @@ public interface MultireleaseSourceSet {
    * @since 2.0.0
    */
   void configureVariants(final @NotNull Action<MultireleaseVariantDetails> action);
+  /**
+   * Register a task to validate that all packages in the module this source set defines are exported.
+   *
+   * @since 2.1.0
+   */
+  void requireAllPackagesExported();
+
+  /**
+   * Register a task to validate that packages in the module this source set defines are exported.
+   *
+   * <p>The task is provided to allow for additional configuration, such as exclusions to required exported packages.</p>
+   *
+   * @param action an action to configure the created task
+   * @since 2.1.0
+   */
+  void requireAllPackagesExported(final @NotNull Action<? super CheckModuleExports> action);
 }

--- a/indra-common/src/main/java/net/kyori/indra/task/CheckModuleExports.java
+++ b/indra-common/src/main/java/net/kyori/indra/task/CheckModuleExports.java
@@ -1,0 +1,200 @@
+/*
+ * This file is part of indra, licensed under the MIT License.
+ *
+ * Copyright (c) 2020-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.indra.task;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipException;
+import java.util.zip.ZipFile;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.SetProperty;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.TaskAction;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ModuleVisitor;
+import org.objectweb.asm.Opcodes;
+
+/**
+ * Validate that all packages within a module are appropriately exported.
+ *
+ * @since 2.1.0
+ */
+public abstract class CheckModuleExports extends DefaultTask {
+  private static final String MULTIRELEASE_PATH_PREFIX = "META-INF/versions/";
+
+  /**
+   * A file property referring to the module jar checked in this task.
+   *
+   * @return the checked module
+   */
+  @InputFile
+  public abstract RegularFileProperty getCheckedModule();
+
+  /**
+   * Get package prefixes that do not have to be exported.
+   *
+   * @return the package exclusion property
+   */
+  @Input
+  public abstract SetProperty<String> getExclusions();
+
+  /**
+   * Add package prefix exclusions for module validation.
+   *
+   * @param prefixes the prefixes to exclude
+   */
+  public void exclude(final String... prefixes) {
+    this.getExclusions().addAll(prefixes);
+  }
+
+  @TaskAction
+  public void validateModule() throws ZipException, IOException {
+    final Set<String> exclusions = this.getExclusions().get();
+    final Set<String> knownPackages = new HashSet<>();
+    final Set<String> exports = new HashSet<>();
+    boolean moduleInfoSeen = false;
+    // require that the checked module is a jar
+    final File inspected = this.getCheckedModule().get().getAsFile();
+    if (!inspected.getName().endsWith(".jar")) {
+      throw new InvalidUserDataException("Inspected file '" + inspected + "' was not a jar, when the CheckModuleExports task expected it to be");
+    }
+
+    // traverse the paths, build a set of directory entries
+    // if path is `module-info`, then read it and get the exported packages
+    try (final ZipFile jar = new ZipFile(inspected)) {
+      for (final Enumeration<? extends ZipEntry> entries = jar.entries(); entries.hasMoreElements();) {
+        final ZipEntry check = entries.nextElement();
+        if (isModuleInfo(check.getName())) {
+          exports.addAll(this.exports(jar.getInputStream(check))); // todo: this just merges all multi-release module descriptors, should we refine our logic further?
+          moduleInfoSeen = true;
+        } else if (!check.isDirectory()) {
+          final @Nullable String packageName = packageNameOf(check.getName());
+          if (packageName != null) {
+            knownPackages.add(packageName);
+          }
+        }
+      }
+    }
+
+    this.getLogger().debug("Detected exported packages: {}", exports);
+    if (!moduleInfoSeen) {
+      throw new InvalidUserDataException("Jar file " + inspected + " did not contain any module descriptor!");
+    }
+
+    final Set<String> exportProblems = this.checkExports(exports, knownPackages, exclusions);
+    if (!exportProblems.isEmpty()) {
+      this.getLogger().error("Some packages in {} were not exported when they were experted to be:", inspected);
+      for (final String problem : exportProblems) {
+        this.getLogger().error("- {}", problem);
+      }
+      throw new GradleException();
+    }
+  }
+
+  private Set<String> checkExports(final Set<String> exported, final Set<String> known, final Set<String> excludedPrefixes) {
+    final Set<String> problems = new HashSet<>(known);
+    problems.removeAll(exported);
+    for (final Iterator<String> it = known.iterator(); it.hasNext();) {
+      final String check = it.next();
+      for (final String prefix : excludedPrefixes) {
+        if (check.startsWith(prefix)) {
+          it.remove();
+          break;
+        }
+      }
+    }
+    return problems;
+  }
+
+  private static boolean isModuleInfo(final @NotNull String path) {
+    return "module-info.class".equals(path) || (path.startsWith(MULTIRELEASE_PATH_PREFIX) && path.endsWith("module-info.class")); // todo: stricter multi-release handling
+  }
+
+  @VisibleForTesting
+  static @Nullable String packageNameOf(@NotNull String file) {
+    if (file.startsWith(MULTIRELEASE_PATH_PREFIX)) { // META-INF/versions: strip prefix
+      final int nextSlash = file.indexOf("/", MULTIRELEASE_PATH_PREFIX.length());
+      if (nextSlash == -1) {
+        return null;
+      }
+      file = file.substring(nextSlash + 1);
+    } else if (file.startsWith("META-INF/")) { // META-INF/: ignore
+      return null;
+    }
+    final int lastSlash = file.lastIndexOf('/');
+    if (lastSlash == -1) {
+      return null;
+    }
+    return file.substring(0, lastSlash).replace('/', '.');
+  }
+
+  private Set<String> exports(final InputStream is) throws IOException {
+    final ClassReader reader = new ClassReader(is);
+    final Set<String> exports = new HashSet<>();
+    reader.accept(new ModuleExportsVisitor(exports), ClassReader.SKIP_CODE | ClassReader.SKIP_FRAMES);
+    return Collections.unmodifiableSet(exports);
+  }
+
+  static final class ModuleExportsVisitor extends ClassVisitor {
+    private static final int ASMAPI = Opcodes.ASM9;
+    private final Set<String> exports;
+
+    public ModuleExportsVisitor(final Set<String> exports) {
+      super(ASMAPI);
+      this.exports = exports;
+    }
+
+    final class Exports extends ModuleVisitor {
+      Exports(final ModuleVisitor parent) {
+        super(ASMAPI, parent);
+      }
+
+      @Override
+      public void visitExport(final String packaze, final int access, final String... modules) {
+        ModuleExportsVisitor.this.exports.add(packaze.replace('/', '.'));
+        super.visitExport(packaze, access, modules);
+      }
+    }
+
+    @Override
+    public ModuleVisitor visitModule(final String name, final int access, final String version) {
+      return new Exports(super.visitModule(name, access, version));
+    }
+  }
+}

--- a/indra-common/src/main/java/net/kyori/indra/task/CheckModuleExports.java
+++ b/indra-common/src/main/java/net/kyori/indra/task/CheckModuleExports.java
@@ -119,7 +119,7 @@ public abstract class CheckModuleExports extends DefaultTask {
 
     final Set<String> exportProblems = this.checkExports(exports, knownPackages, exclusions);
     if (!exportProblems.isEmpty()) {
-      this.getLogger().error("Some packages in {} were not exported when they were experted to be:", inspected);
+      this.getLogger().error("Some packages in {} were not exported when they were expected to be:", inspected);
       for (final String problem : exportProblems) {
         this.getLogger().error("- {}", problem);
       }

--- a/indra-common/src/main/java/net/kyori/indra/task/JDeps.java
+++ b/indra-common/src/main/java/net/kyori/indra/task/JDeps.java
@@ -1,0 +1,201 @@
+/*
+ * This file is part of indra, licensed under the MIT License.
+ *
+ * Copyright (c) 2020-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.indra.task;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import javax.inject.Inject;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.JavaVersion;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
+import org.gradle.jvm.toolchain.JavaLauncher;
+import org.gradle.jvm.toolchain.JavaToolchainService;
+import org.gradle.process.CommandLineArgumentProvider;
+import org.gradle.process.ExecOperations;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Execute the {@code jdeps} tool.
+ *
+ * @since 2.1.0
+ */
+public abstract class JDeps extends DefaultTask {
+  private final List<CommandLineArgumentProvider> argumentProviders = new ArrayList<>();
+
+  /**
+   * Get the module path to pass to the JDeps tool.
+   *
+   * @return a file collection representing the module path to pass to the tool
+   * @since 2.1.0
+   */
+  @InputFiles
+  public abstract ConfigurableFileCollection getModulePath();
+
+  /**
+   * Set the Java instance to execute the {@code jdeps} tool with.
+   *
+   * @return a property pointing to the java launcher
+   * @since 2.1.0
+   */
+  @Input
+  public abstract Property<JavaLauncher> getJavaLauncher();
+
+  /**
+   * Class files, directories, and/or JAR files to process.
+   *
+   * @return the collection
+   * @since 2.1.0
+   */
+  @Optional
+  @InputFiles
+  public abstract ConfigurableFileCollection getProcessClasses();
+
+  /**
+   * Free-form arguments to pass to {@code jdeps}.
+   *
+   * @return a list property of arguments to pass
+   * @since 2.1.0
+   */
+  @Input
+  @Optional
+  public abstract ListProperty<String> getArguments();
+
+  /**
+   * Extra argument providers to generate jdeps arguments.
+   *
+   * @return argument providers
+   * @since 2.1.0
+   */
+  @Nested
+  public List<CommandLineArgumentProvider> getArgumentProviders() {
+    return this.argumentProviders;
+  }
+
+  /**
+   * Set the specific version to test against given a multi-release input jar.
+   *
+   * @return the version to test against
+   * @since 2.1.0
+   */
+  @Input
+  @Optional
+  public abstract Property<Integer> getMultireleaseVersion();
+
+  public void argumentProvider(final CommandLineArgumentProvider argumentProvider) {
+    this.argumentProviders.add(requireNonNull(argumentProvider, "argumentProvider"));
+  }
+
+  @Inject
+  protected abstract JavaToolchainService getToolchains();
+
+  @Inject
+  protected abstract ExecOperations getExecOps();
+
+  /**
+   * Create a new task instance.
+   *
+   * <p>Not to be called directly</p>
+   *
+   * @since 2.1.0
+   */
+  public JDeps() {
+    this.getJavaLauncher().convention(this.getToolchains()
+      .launcherFor(spec -> spec.getLanguageVersion().set(JavaLanguageVersion.of(JavaVersion.current().toString()))));
+      this.getMultireleaseVersion().finalizeValueOnRead();
+  }
+
+  /**
+   * Calculate all arguments for the task, using freeform arguments and argument providers.
+   *
+   * @return all arguments
+   * @since 2.1.0
+   */
+  @Internal
+  public List<String> getAllArguments() {
+    final List<String> args = new ArrayList<>(this.getArguments().get());
+    for (final CommandLineArgumentProvider clap : this.getArgumentProviders()) {
+      final Iterable<String> provided = clap.asArguments();
+      if (provided instanceof Collection<?>) {
+        args.addAll((Collection<String>) provided);
+      } else {
+        for (final String arg : provided) {
+          args.add(arg);
+        }
+      }
+    }
+    return args;
+  }
+
+  private File findJDeps() {
+    final JavaLauncher launcher = this.getJavaLauncher().get();
+    final File executable = launcher.getExecutablePath().getAsFile();
+    final String jdepsFileName;
+    final int dotIdx = executable.getName().indexOf('.');
+    if (dotIdx != -1) {
+      jdepsFileName = "jdeps" + executable.getName().substring(dotIdx);
+    } else {
+      jdepsFileName = "jdeps";
+    }
+    final File jdeps = new File(executable.getParentFile(), jdepsFileName);
+    if (!jdeps.exists()) {
+      throw new InvalidUserDataException("Toolchain of version " + launcher.getMetadata().getLanguageVersion() + " did not have a jdeps executable.");
+    }
+    return jdeps;
+  }
+
+  /**
+   * Execute the task.
+   *
+   * @since 2.1.0
+   */
+  @TaskAction
+  public void execute() {
+    // TODO: Use ToolProvider API when available? would need a J9 source set
+    final File jdeps = this.findJDeps();
+    this.getExecOps().exec(spec -> {
+      spec.setExecutable(jdeps);
+      if (this.getMultireleaseVersion().isPresent()) {
+        spec.args("--multi-release", this.getMultireleaseVersion().get().toString());
+      }
+      spec.args("--module-path", this.getModulePath().getAsPath()); // TODO: split between classpath and module path
+      spec.args(this.getAllArguments());
+      for (final File file : this.getProcessClasses()) {
+        spec.args(file.getAbsolutePath());
+      }
+    }).assertNormalExitValue();
+  }
+}

--- a/indra-common/src/test/java/net/kyori/indra/task/CheckModuleExportsTest.java
+++ b/indra-common/src/test/java/net/kyori/indra/task/CheckModuleExportsTest.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of indra, licensed under the MIT License.
+ *
+ * Copyright (c) 2020-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.indra.task;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class CheckModuleExportsTest {
+  @Test
+  void testPackageNameOfClass() {
+    assertEquals("net.kyori", CheckModuleExports.packageNameOf("net/kyori/Something.class"));
+  }
+
+  @Test
+  void metaInfFileIsNull() {
+    assertNull(CheckModuleExports.packageNameOf("META-INF/project.pom"));
+  }
+
+  @Test
+  void testDefaultPackage() {
+    assertNull(CheckModuleExports.packageNameOf("DefaultPackage.class"));
+  }
+
+  @Test
+  void testMultireleasePackage() {
+    assertEquals("net.kyori.indra", CheckModuleExports.packageNameOf("META-INF/versions/17/net/kyori/indra/Indra.class"));
+  }
+}


### PR DESCRIPTION
- A module requires validation task using JDeps
- A module exports validation task to ensure all (or all not specifically excluded) packages are exported

Closes GH-35
Closes GH-49