### PR TITLE
introduce language support system for other JVM languages

### DIFF
--- a/indra-common/build.gradle
+++ b/indra-common/build.gradle
@@ -14,6 +14,21 @@ kotlin {
   }
 }
 
+sourceSets {
+  kotlinSupport
+}
+
+tasks.named('jar').configure {
+  from(sourceSets.kotlinSupport.output)
+}
+
+pluginUnderTestMetadata {
+  // Use a packaged form of our plugin to support our classpath hackery
+  // def oldFrom = pluginClasspath.from
+  pluginClasspath.from = tasks.named('jar').map { it.outputs }
+  pluginClasspath.from sourceSets.main.runtimeClasspath
+}
+
 dependencies {
   compileOnlyApi "org.immutables:value:2.8.8:annotations"
   annotationProcessor "org.immutables:value:2.8.8"
@@ -24,6 +39,11 @@ dependencies {
   implementation "org.ow2.asm:asm:9.2"
   api "net.kyori:mammoth:$mammothVersion"
   testImplementation project(":indra-testlib")
+  
+  // Kotlin plugin dep
+  kotlinSupportCompileOnly "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10"
+  kotlinSupportCompileOnly(gradleApi())
+  compileOnly(sourceSets.kotlinSupport.output)
 }
 
 indraPluginPublishing {

--- a/indra-common/src/kotlinSupport/java/net/kyori/indra/internal/language/KotlinShim.java
+++ b/indra-common/src/kotlinSupport/java/net/kyori/indra/internal/language/KotlinShim.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of indra, licensed under the MIT License.
+ *
+ * Copyright (c) 2020-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.indra.internal.language;
+
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.TaskContainer;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
+import org.gradle.jvm.toolchain.JavaLauncher;
+import org.gradle.jvm.toolchain.JavaToolchainService;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile;
+import org.jetbrains.kotlin.gradle.tasks.UsesKotlinJavaToolchain;
+
+public final class KotlinShim {
+
+  public static void configureCompileTasks(
+    final JavaToolchainService toolchains,
+    final @NotNull TaskContainer tasks,
+    final @NotNull SourceSet sourceSet,
+    final @NotNull Provider<Integer> toolchainVersion,
+    final @NotNull Provider<Integer> bytecodeVersion
+  ) {
+    final Provider<JavaLauncher> launcher = toolchains.launcherFor(spec -> spec.getLanguageVersion().set(bytecodeVersion.map(v -> JavaLanguageVersion.of(v))));
+    tasks.named(sourceSet.getCompileTaskName("kotlin"), UsesKotlinJavaToolchain.class, task -> {
+      task.getKotlinJavaToolchain().getToolchain().use(launcher);
+      if (task instanceof KotlinCompile) {
+        final KotlinCompile kc = (KotlinCompile) task;
+        task.getInputs().property("bytecodeVersion", bytecodeVersion);
+        // TODO: this is kinda bad, but we can't add an action because this class is loaded in a non-Gradle class loader.
+        kc.getKotlinOptions().setJvmTarget(org.gradle.api.JavaVersion.toVersion(bytecodeVersion.get()).toString());
+      }
+    });
+  }
+}

--- a/indra-common/src/main/java/net/kyori/indra/internal/SelfPreferringClassLoader.java
+++ b/indra-common/src/main/java/net/kyori/indra/internal/SelfPreferringClassLoader.java
@@ -1,0 +1,114 @@
+/*
+ * This file is part of indra, licensed under the MIT License.
+ *
+ * Copyright (c) 2020-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.indra.internal;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Enumeration;
+import java.util.NoSuchElementException;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A classloader that will load classes from itself rather than its parent where possible.
+ */
+public class SelfPreferringClassLoader extends URLClassLoader {
+  static {
+    ClassLoader.registerAsParallelCapable();
+  }
+  private final ClassLoader parent;
+
+  public SelfPreferringClassLoader(final URL[] urls, final ClassLoader parent) {
+    super(urls, parent);
+    this.parent = parent;
+  }
+
+  @Override
+  protected Class<?> loadClass(final String name, final boolean resolve) throws ClassNotFoundException {
+    synchronized (this.getClassLoadingLock(name)) {
+      Class<?> result = this.findLoadedClass(name);
+      if (result == null) {
+        try {
+          result = this.findClass(name);
+        } catch (final ClassNotFoundException ex) {
+          // ignore, delegate to parent
+        }
+      }
+      if (result == null) {
+        return super.loadClass(name, resolve);
+      }
+      if (resolve) {
+        this.resolveClass(result);
+      }
+      return result;
+    }
+  }
+
+  @Override
+  public @Nullable URL getResource(final String name) {
+    @Nullable
+    URL result = this.findResource(name);
+    if (result == null) {
+      result = super.getResource(name);
+    }
+    return result;
+  }
+
+  @Override
+  public Enumeration<URL> getResources(final String name) throws IOException {
+    return new Enumeration<URL>() {
+      @Nullable
+      Enumeration<URL> active = SelfPreferringClassLoader.this.findResources(name);
+      @Nullable
+      Enumeration<URL> staged = SelfPreferringClassLoader.this.parent == null
+        ? ClassLoader.getSystemClassLoader().getResources(name)
+        : SelfPreferringClassLoader.this.parent.getResources(name);
+
+      private @Nullable Enumeration<URL> nextComponent() {
+        if (this.active == null) {
+          return null;
+        } else if (!this.active.hasMoreElements()) {
+          this.active = this.staged;
+          this.staged = null;
+        }
+        return this.active;
+      }
+
+      @Override
+      public boolean hasMoreElements() {
+        final @Nullable Enumeration<URL> component = this.nextComponent();
+        return component != null && component.hasMoreElements();
+      }
+
+      @Override
+      public URL nextElement() {
+        final @Nullable Enumeration<URL> component = this.nextComponent();
+        if (component == null) {
+          throw new NoSuchElementException();
+        }
+        return component.nextElement();
+      }
+    };
+  }
+}

--- a/indra-common/src/main/java/net/kyori/indra/internal/language/GroovySupport.java
+++ b/indra-common/src/main/java/net/kyori/indra/internal/language/GroovySupport.java
@@ -51,9 +51,7 @@ public class GroovySupport implements LanguageSupport {
 
   @Override
   public void registerApplyCallback(final @NotNull Project project, final @NotNull Action<? super Project> callback) {
-    System.out.println("Registering Groovy callback");
     project.getPlugins().withType(GroovyPlugin.class, $ -> {
-      System.out.println("Executing Groovy callback");
       callback.execute(project);
     });
   }
@@ -62,7 +60,6 @@ public class GroovySupport implements LanguageSupport {
   public void configureCompileTasks(final Project project, final SourceSet sourceSet, final Provider<Integer> toolchainVersion, final Provider<Integer> bytecodeVersion) {
     final Provider<JavaLauncher> launcher = this.toolchains.launcherFor(spec -> spec.getLanguageVersion().set(bytecodeVersion.map(v -> JavaLanguageVersion.of(v))));
     project.getTasks().named(sourceSet.getCompileTaskName(GROOVY), GroovyCompile.class, groovyCompile -> {
-      System.out.println("Configuring " + groovyCompile.getName());
       groovyCompile.getOptions().getRelease().set(bytecodeVersion);
       if (HAS_GRADLE_7_2) {
         // The Groovy plugin doesn't allow cross-compiling, so we have to use the specific target JDK

--- a/indra-common/src/main/java/net/kyori/indra/internal/language/GroovySupport.java
+++ b/indra-common/src/main/java/net/kyori/indra/internal/language/GroovySupport.java
@@ -1,0 +1,85 @@
+/*
+ * This file is part of indra, licensed under the MIT License.
+ *
+ * Copyright (c) 2020-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.indra.internal.language;
+
+import javax.inject.Inject;
+import org.gradle.api.Action;
+import org.gradle.api.JavaVersion;
+import org.gradle.api.Project;
+import org.gradle.api.plugins.GroovyPlugin;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.compile.GroovyCompile;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
+import org.gradle.jvm.toolchain.JavaLauncher;
+import org.gradle.jvm.toolchain.JavaToolchainService;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Support for Groovy-language plugins
+ */
+public class GroovySupport implements LanguageSupport {
+  private static final String GROOVY = "groovy";
+
+  private final JavaToolchainService toolchains;
+
+  @Inject
+  public GroovySupport(final JavaToolchainService toolchains) {
+    this.toolchains = toolchains;
+  }
+
+  @Override
+  public void registerApplyCallback(final @NotNull Project project, final @NotNull Action<? super Project> callback) {
+    System.out.println("Registering Groovy callback");
+    project.getPlugins().withType(GroovyPlugin.class, $ -> {
+      System.out.println("Executing Groovy callback");
+      callback.execute(project);
+    });
+  }
+
+  @Override
+  public void configureCompileTasks(final Project project, final SourceSet sourceSet, final Provider<Integer> toolchainVersion, final Provider<Integer> bytecodeVersion) {
+    final Provider<JavaLauncher> launcher = this.toolchains.launcherFor(spec -> spec.getLanguageVersion().set(bytecodeVersion.map(v -> JavaLanguageVersion.of(v))));
+    project.getTasks().named(sourceSet.getCompileTaskName(GROOVY), GroovyCompile.class, groovyCompile -> {
+      System.out.println("Configuring " + groovyCompile.getName());
+      groovyCompile.getOptions().getRelease().set(bytecodeVersion);
+      if (HAS_GRADLE_7_2) {
+        // The Groovy plugin doesn't allow cross-compiling, so we have to use the specific target JDK
+        groovyCompile.getJavaLauncher().set(launcher);
+      }
+      final String compatibility = JavaVersion.toVersion(bytecodeVersion.get()).toString();
+      groovyCompile.setSourceCompatibility(compatibility);
+      groovyCompile.setTargetCompatibility(compatibility);
+
+      groovyCompile.getGroovyOptions().setEncoding(DEFAULT_ENCODING);
+    });
+  }
+
+  /*@Override
+  public void configureDocTasks(@NotNull Project project, @NotNull SourceSet sourceSet, @NotNull Provider<Integer> toolchainVersion, @NotNull Provider<Integer> targetVersion) {
+    project.getTasks().withType(Groovydoc.class).matching(t -> t.getName().equals(sourceSet.getTaskName(null, GroovyPlugin.GROOVYDOC_TASK_NAME))).configureEach(task -> {
+      task.get
+    });
+  }*/
+}

--- a/indra-common/src/main/java/net/kyori/indra/internal/language/JavaSupport.java
+++ b/indra-common/src/main/java/net/kyori/indra/internal/language/JavaSupport.java
@@ -1,0 +1,168 @@
+/*
+ * This file is part of indra, licensed under the MIT License.
+ *
+ * Copyright (c) 2020-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.indra.internal.language;
+
+import java.util.Arrays;
+import java.util.Collections;
+import javax.inject.Inject;
+import net.kyori.indra.util.Versioning;
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.compile.CompileOptions;
+import org.gradle.api.tasks.compile.JavaCompile;
+import org.gradle.api.tasks.javadoc.Javadoc;
+import org.gradle.external.javadoc.JavadocOptionFileOption;
+import org.gradle.external.javadoc.MinimalJavadocOptions;
+import org.gradle.external.javadoc.StandardJavadocDocletOptions;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
+import org.gradle.jvm.toolchain.JavaToolchainService;
+import org.gradle.jvm.toolchain.JavadocTool;
+import org.gradle.process.CommandLineArgumentProvider;
+import org.jetbrains.annotations.NotNull;
+
+public class JavaSupport implements LanguageSupport {
+  private final JavaToolchainService toolchains;
+
+  @Inject
+  public JavaSupport(final JavaToolchainService toolchains) {
+    this.toolchains = toolchains;
+  }
+
+  @Override
+  public void registerApplyCallback(final @NotNull Project project, final @NotNull Action<? super Project> callback) {
+    project.getPlugins().withType(JavaPlugin.class, $ -> {
+      callback.execute(project);
+    });
+  }
+
+  @Override
+  public void configureCompileTasks(final @NotNull Project project, final @NotNull SourceSet sourceSet, final @NotNull Provider<Integer> toolchainVersion, final @NotNull Provider<Integer> bytecodeVersion) {
+    project.getTasks().named(sourceSet.getCompileJavaTaskName(), JavaCompile.class, task -> {
+      final CompileOptions options = task.getOptions();
+      options.setEncoding(DEFAULT_ENCODING);
+      task.getJavaCompiler().set(this.toolchains.compilerFor(spec -> spec.getLanguageVersion().set(toolchainVersion.map(v -> JavaLanguageVersion.of(v)))));
+
+      options.getRelease().set(bytecodeVersion.zip(toolchainVersion, (bytecode, toolchain) -> {
+        if (toolchain >= 9) {
+          return bytecode;
+        } else {
+          return null;
+        }
+      }));
+
+      options.getCompilerArgumentProviders().add(new IndraCompileArgumentProvider(toolchainVersion));
+    });
+  }
+
+  @Override
+  public void configureDocTasks(@NotNull final Project project, @NotNull final SourceSet sourceSet, @NotNull final Provider<Integer> toolchainVersion, @NotNull final Provider<Integer> targetVersion) {
+    final String taskName = sourceSet.getJavadocTaskName();
+    final Provider<JavadocTool> javadocTool = this.toolchains.javadocToolFor(spec -> spec.getLanguageVersion().set(toolchainVersion.map(v -> JavaLanguageVersion.of(v))));
+    project.getTasks().withType(Javadoc.class).matching(t -> t.getName().equals(taskName)).configureEach(task -> {
+      final MinimalJavadocOptions minimalOpts = task.getOptions();
+      minimalOpts.setEncoding(DEFAULT_ENCODING);
+      task.getJavadocTool().set(javadocTool);
+
+      if(minimalOpts instanceof StandardJavadocDocletOptions) {
+        final StandardJavadocDocletOptions options = (StandardJavadocDocletOptions) minimalOpts;
+        options.charSet(DEFAULT_ENCODING);
+
+        task.doFirst(new IndraJavadocPrepareAction(targetVersion, options));
+      }
+    });
+  }
+
+  static final class IndraCompileArgumentProvider implements CommandLineArgumentProvider {
+    private final @NotNull Provider<Integer> toolchainVersion;
+
+    public IndraCompileArgumentProvider(final @NotNull Provider<Integer> toolchainVersion) {
+      this.toolchainVersion = toolchainVersion;
+    }
+
+    @Override
+    public Iterable<String> asArguments() {
+      if(this.toolchainVersion.get() >= 9) {
+        return Arrays.asList(
+          "-Xdoclint",
+          "-Xdoclint:-missing"
+        );
+      } else {
+        return Collections.emptyList();
+      }
+    }
+  }
+
+  static final class IndraJavadocPrepareAction implements Action<Task> {
+    private final @NotNull Provider<Integer> targetVersion;
+    private final JavadocOptionFileOption<Boolean> doclintMissing;
+    private final JavadocOptionFileOption<Boolean> html5;
+    private final JavadocOptionFileOption<String> release;
+    private final JavadocOptionFileOption<Boolean> noModuleDirectories;
+
+    IndraJavadocPrepareAction(final @NotNull Provider<Integer> targetVersion, final StandardJavadocDocletOptions initOptions) {
+      this.targetVersion = targetVersion;
+      this.doclintMissing = initOptions.addBooleanOption("Xdoclint:-missing");
+      this.html5 = initOptions.addBooleanOption("html5");
+      this.release = initOptions.addStringOption("-release");
+      this.noModuleDirectories = initOptions.addBooleanOption("-no-module-directories");
+    }
+
+    @Override
+    public void execute(final Task t) {
+      final StandardJavadocDocletOptions options = (StandardJavadocDocletOptions) ((Javadoc) t).getOptions();
+      final int target = this.targetVersion.get();
+      final int actual = ((Javadoc) t).getJavadocTool().get().getMetadata().getLanguageVersion().asInt();
+      // Java 16 automatically links with the API documentation anyways
+      if (actual < 16) {
+        options.links(jdkApiDocs(target));
+      }
+      if (actual >= 9) {
+        if (actual < 12) {
+          // Apply workaround for https://bugs.openjdk.java.net/browse/JDK-8215291
+          // Hopefully this gets backported some day... (JDK-8215291)
+          this.noModuleDirectories.setValue(true);
+        }
+        this.release.setValue(Integer.toString(target));
+        this.doclintMissing.setValue(true);
+        this.html5.setValue(true);
+      } else {
+        options.setSource(Versioning.versionString(target));
+      }
+    }
+  }
+
+  private static String jdkApiDocs(final int javaVersion) {
+    final String template;
+    if(javaVersion >= 11) {
+      template = "https://docs.oracle.com/en/java/javase/%s/docs/api";
+    } else {
+      template = "https://docs.oracle.com/javase/%s/docs/api";
+    }
+    return String.format(template, javaVersion);
+  }
+}

--- a/indra-common/src/main/java/net/kyori/indra/internal/language/JavaSupport.java
+++ b/indra-common/src/main/java/net/kyori/indra/internal/language/JavaSupport.java
@@ -74,7 +74,6 @@ public class JavaSupport implements LanguageSupport {
           return null;
         }
       }));
-
       options.getCompilerArgumentProviders().add(new IndraCompileArgumentProvider(toolchainVersion));
     });
   }
@@ -92,6 +91,7 @@ public class JavaSupport implements LanguageSupport {
         final StandardJavadocDocletOptions options = (StandardJavadocDocletOptions) minimalOpts;
         options.charSet(DEFAULT_ENCODING);
 
+        task.getInputs().property("targetVersion", targetVersion);
         task.doFirst(new IndraJavadocPrepareAction(targetVersion, options));
       }
     });
@@ -119,17 +119,11 @@ public class JavaSupport implements LanguageSupport {
 
   static final class IndraJavadocPrepareAction implements Action<Task> {
     private final @NotNull Provider<Integer> targetVersion;
-    private final JavadocOptionFileOption<Boolean> doclintMissing;
-    private final JavadocOptionFileOption<Boolean> html5;
     private final JavadocOptionFileOption<String> release;
-    private final JavadocOptionFileOption<Boolean> noModuleDirectories;
 
     IndraJavadocPrepareAction(final @NotNull Provider<Integer> targetVersion, final StandardJavadocDocletOptions initOptions) {
       this.targetVersion = targetVersion;
-      this.doclintMissing = initOptions.addBooleanOption("Xdoclint:-missing");
-      this.html5 = initOptions.addBooleanOption("html5");
       this.release = initOptions.addStringOption("-release");
-      this.noModuleDirectories = initOptions.addBooleanOption("-no-module-directories");
     }
 
     @Override
@@ -142,14 +136,7 @@ public class JavaSupport implements LanguageSupport {
         options.links(jdkApiDocs(target));
       }
       if (actual >= 9) {
-        if (actual < 12) {
-          // Apply workaround for https://bugs.openjdk.java.net/browse/JDK-8215291
-          // Hopefully this gets backported some day... (JDK-8215291)
-          this.noModuleDirectories.setValue(true);
-        }
         this.release.setValue(Integer.toString(target));
-        this.doclintMissing.setValue(true);
-        this.html5.setValue(true);
       } else {
         options.setSource(Versioning.versionString(target));
       }

--- a/indra-common/src/main/java/net/kyori/indra/internal/language/KotlinSupport.java
+++ b/indra-common/src/main/java/net/kyori/indra/internal/language/KotlinSupport.java
@@ -1,0 +1,117 @@
+/*
+ * This file is part of indra, licensed under the MIT License.
+ *
+ * Copyright (c) 2020-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.indra.internal.language;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Map;
+import java.util.WeakHashMap;
+import javax.inject.Inject;
+import net.kyori.indra.internal.SelfPreferringClassLoader;
+import org.gradle.api.Action;
+import org.gradle.api.GradleException;
+import org.gradle.api.Project;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.TaskContainer;
+import org.gradle.jvm.toolchain.JavaToolchainService;
+import org.jetbrains.annotations.NotNull;
+
+public class KotlinSupport implements LanguageSupport {
+  private static final String KOTLIN_PLUGIN = "org.jetbrains.kotlin.jvm";
+  private static final String SENTINEL_CLASS = "org.jetbrains.kotlin.gradle.tasks.KotlinCompile";
+
+  private final JavaToolchainService toolchains;
+  private final ThreadLocal<KotlinInvoker> childClass = ThreadLocal.withInitial(() -> null);
+  private final Map<org.gradle.api.Plugin<?>, KotlinInvoker> invokers = new WeakHashMap<>();
+
+  @Inject
+  public KotlinSupport(final JavaToolchainService toolchains) {
+    this.toolchains = toolchains;
+  }
+
+  @Override
+  public void registerApplyCallback(final @NotNull Project project, final @NotNull Action<? super Project> callback) {
+    project.getPlugins().withId(KOTLIN_PLUGIN, pl -> {
+      // Create a classloader for us, if necessary
+      synchronized (this.invokers) {
+        this.childClass.set(this.invokers.computeIfAbsent(pl, key -> {
+          try {
+            try {
+              this.getClass().getClassLoader().loadClass(SENTINEL_CLASS);
+              return new KotlinInvoker(this.getClass().getClassLoader());
+            } catch (final ClassNotFoundException ex) {
+              final URLClassLoader classLoader = new SelfPreferringClassLoader(
+                  new URL[]{KotlinSupport.class.getProtectionDomain().getCodeSource().getLocation()},
+                  key.getClass().getClassLoader()
+              );
+              return new KotlinInvoker(classLoader);
+            }
+          } catch (final ReflectiveOperationException ex) {
+            throw new GradleException("Unable to create a Kotlin invoker", ex);
+          }
+        }));
+      }
+
+      try {
+        callback.execute(project);
+      } finally {
+        this.childClass.remove();
+      }
+    });
+
+  }
+
+  @Override
+  public void configureCompileTasks(final @NotNull Project project, final @NotNull SourceSet sourceSet, final @NotNull Provider<Integer> toolchainVersion, final @NotNull Provider<Integer> bytecodeVersion) {
+    this.childClass.get().configureCompileTasks(this.toolchains, project.getTasks(), sourceSet, toolchainVersion, bytecodeVersion);
+  }
+
+  static final class KotlinInvoker {
+    private static final String KOTLIN_SHIM = "net.kyori.indra.internal.language.KotlinShim";
+
+    private final Method configureCompileTasks;
+
+    KotlinInvoker(final ClassLoader loader) throws ReflectiveOperationException {
+      final Class<?> kotlinShim = loader.loadClass(KOTLIN_SHIM);
+      this.configureCompileTasks = kotlinShim.getMethod("configureCompileTasks", JavaToolchainService.class, TaskContainer.class, SourceSet.class, Provider.class, Provider.class);
+    }
+
+    void configureCompileTasks(
+      final JavaToolchainService toolchains,
+      final @NotNull TaskContainer tasks,
+      final @NotNull SourceSet sourceSet,
+      final @NotNull Provider<Integer> toolchainVersion,
+      final @NotNull Provider<Integer> bytecodeVersion
+    ) {
+      try {
+        this.configureCompileTasks.invoke(null, toolchains, tasks, sourceSet, toolchainVersion, bytecodeVersion);
+      } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
+        throw new GradleException("Failed to invoke compile task configuration step for Kotlin source set", ex);
+      }
+    }
+  }
+}

--- a/indra-common/src/main/java/net/kyori/indra/internal/language/LanguageSupport.java
+++ b/indra-common/src/main/java/net/kyori/indra/internal/language/LanguageSupport.java
@@ -1,0 +1,82 @@
+/*
+ * This file is part of indra, licensed under the MIT License.
+ *
+ * Copyright (c) 2020-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.indra.internal.language;
+
+import java.nio.charset.StandardCharsets;
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.util.GradleVersion;
+import org.jetbrains.annotations.NotNull;
+
+public interface LanguageSupport {
+  String DEFAULT_ENCODING = StandardCharsets.UTF_8.name();
+  boolean HAS_GRADLE_7_2 = GradleVersion.current().compareTo(GradleVersion.version("7.2")) >= 0;
+
+  void registerApplyCallback(
+    final @NotNull Project project,
+    final @NotNull Action<? super Project> callback
+  );
+
+  /**
+   * Configure compile tasks.
+   *
+   * <ul>
+   * <li>Toolchain and target versions</li>
+   * <li>set encoding to UTF-8</li>
+   * </ul>
+   *
+   * @param project project to configure
+   * @param sourceSet source set to find compile tasks in
+   * @param toolchainVersion the version to run on
+   * @param bytecodeVersion the version to target
+   */
+  void configureCompileTasks(
+    final @NotNull Project project,
+    final @NotNull SourceSet sourceSet,
+    final @NotNull Provider<Integer> toolchainVersion,
+    final @NotNull Provider<Integer> bytecodeVersion
+  );
+
+  /**
+   * Configure documentation tasks.
+   *
+   * <ul>
+   * <li>Toolchain and target versions</li>
+   * <li>set encoding to UTF-8</li>
+   * </ul>
+   *
+   * @param project project to configure
+   * @param sourceSet source set to find compile tasks in
+   * @param toolchainVersion the Java version to run on
+   * @param targetVersion the Java version to target
+   */
+  default void configureDocTasks(
+    final @NotNull Project project,
+    final @NotNull SourceSet sourceSet,
+    final @NotNull Provider<Integer> toolchainVersion,
+    final @NotNull Provider<Integer> targetVersion
+  ) {};
+}

--- a/indra-common/src/main/java/net/kyori/indra/internal/language/ScalaSupport.java
+++ b/indra-common/src/main/java/net/kyori/indra/internal/language/ScalaSupport.java
@@ -1,0 +1,103 @@
+/*
+ * This file is part of indra, licensed under the MIT License.
+ *
+ * Copyright (c) 2020-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.indra.internal.language;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.inject.Inject;
+import org.gradle.api.Action;
+import org.gradle.api.JavaVersion;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.plugins.scala.ScalaPlugin;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.scala.ScalaCompile;
+import org.gradle.api.tasks.scala.ScalaCompileOptions;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
+import org.gradle.jvm.toolchain.JavaLauncher;
+import org.gradle.jvm.toolchain.JavaToolchainService;
+import org.jetbrains.annotations.NotNull;
+
+public class ScalaSupport implements LanguageSupport {
+  private final JavaToolchainService toolchains;
+
+  @Inject
+  public ScalaSupport(final JavaToolchainService toolchains) {
+    this.toolchains = toolchains;
+  }
+
+  @Override
+  public void registerApplyCallback(final @NotNull Project project, final @NotNull Action<? super Project> callback) {
+    project.getPlugins().withType(ScalaPlugin.class, $ -> {
+      callback.execute(project);
+    });
+  }
+
+  @Override
+  public void configureCompileTasks(final @NotNull Project project, final @NotNull SourceSet sourceSet, final @NotNull Provider<Integer> toolchainVersion, final @NotNull Provider<Integer> bytecodeVersion) {
+    final Provider<JavaLauncher> launcher = this.toolchains.launcherFor(spec -> spec.getLanguageVersion().set(toolchainVersion.map(v -> JavaLanguageVersion.of(v))));
+    project.getTasks().named(sourceSet.getCompileTaskName("scala"), ScalaCompile.class, task -> {
+      final ScalaCompileOptions options = task.getScalaCompileOptions();
+      options.setEncoding(DEFAULT_ENCODING);
+      options.setDeprecation(true);
+
+      if (HAS_GRADLE_7_2) {
+        task.getJavaLauncher().set(launcher);
+      }
+
+      final String compatibility = JavaVersion.toVersion(bytecodeVersion.get()).toString();
+      task.setSourceCompatibility(compatibility);
+      task.setTargetCompatibility(compatibility);
+      task.getOptions().getRelease().set(bytecodeVersion);
+      task.doFirst(new ParameterAdder(bytecodeVersion));
+    });
+  }
+
+  static class ParameterAdder implements Action<Task> {
+    private final @NotNull Provider<Integer> target;
+
+    public ParameterAdder(final Provider<Integer> target) {
+      this.target = target;
+    }
+
+    @Override
+    public void execute(final Task task) {
+      List<String> options = ((ScalaCompile) task).getScalaCompileOptions().getAdditionalParameters();
+      if (options != null && options.stream().anyMatch(opt -> opt.startsWith("-target:"))) {
+        return;
+      } else if (options == null) {
+        options = new ArrayList<>();
+        ((ScalaCompile) task).getScalaCompileOptions().setAdditionalParameters(options);
+      }
+
+      options.add("-target:" + this.target.get());
+    }
+  }
+
+  // TODO: Scaladoc
+  // -target:<bytecodeVersion>
+  // -jdk-api-doc-base
+  //
+}

--- a/indra-common/src/main/java/net/kyori/indra/internal/multirelease/IndraMultireleasePlugin.java
+++ b/indra-common/src/main/java/net/kyori/indra/internal/multirelease/IndraMultireleasePlugin.java
@@ -35,6 +35,7 @@ import net.kyori.indra.IndraExtension;
 import net.kyori.indra.internal.ModularityDetecter;
 import net.kyori.indra.internal.language.GroovySupport;
 import net.kyori.indra.internal.language.JavaSupport;
+import net.kyori.indra.internal.language.KotlinSupport;
 import net.kyori.indra.internal.language.LanguageSupport;
 import net.kyori.indra.internal.language.ScalaSupport;
 import net.kyori.indra.multirelease.MultireleaseSourceSet;
@@ -99,7 +100,8 @@ public class IndraMultireleasePlugin implements ProjectPlugin {
   private static final List<Class<? extends LanguageSupport>> SUPPORTED_LANGUAGES = Collections.unmodifiableList(Arrays.asList(
     JavaSupport.class,
     GroovySupport.class,
-    ScalaSupport.class
+    ScalaSupport.class,
+    KotlinSupport.class
   ));
 
   private static final String MULTI_RELEASE_ATTRIBUTE = "Multi-Release";

--- a/indra-common/src/main/java/net/kyori/indra/task/CheckModuleExports.java
+++ b/indra-common/src/main/java/net/kyori/indra/task/CheckModuleExports.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
+import net.kyori.indra.internal.ModularityDetecter;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.InvalidUserDataException;
@@ -100,7 +101,7 @@ public abstract class CheckModuleExports extends DefaultTask {
     try (final ZipFile jar = new ZipFile(inspected)) {
       for (final Enumeration<? extends ZipEntry> entries = jar.entries(); entries.hasMoreElements();) {
         final ZipEntry check = entries.nextElement();
-        if (isModuleInfo(check.getName())) {
+        if (ModularityDetecter.isModuleInfo(check.getName())) {
           exports.addAll(this.exports(jar.getInputStream(check))); // todo: this just merges all multi-release module descriptors, should we refine our logic further?
           moduleInfoSeen = true;
         } else if (!check.isDirectory()) {
@@ -140,10 +141,6 @@ public abstract class CheckModuleExports extends DefaultTask {
       }
     }
     return problems;
-  }
-
-  private static boolean isModuleInfo(final @NotNull String path) {
-    return "module-info.class".equals(path) || (path.startsWith(MULTIRELEASE_PATH_PREFIX) && path.endsWith("module-info.class")); // todo: stricter multi-release handling
   }
 
   @VisibleForTesting

--- a/indra-common/src/test/java/net/kyori/indra/IndraPluginFunctionalTest.java
+++ b/indra-common/src/test/java/net/kyori/indra/IndraPluginFunctionalTest.java
@@ -33,6 +33,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import net.kyori.indra.test.FunctionalTestDisplayNameGenerator;
 import net.kyori.indra.test.IndraConfigCacheFunctionalTest;
+import net.kyori.indra.test.IndraFunctionalTest;
 import net.kyori.mammoth.test.TestContext;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.TaskOutcome;
@@ -89,6 +90,19 @@ class IndraPluginFunctionalTest {
     final Path builtJar = ctx.outputDirectory().resolve("build/libs/scala-1.0.0-SNAPSHOT.jar");
     assertTrue(Files.exists(builtJar));
     assertBytecodeVersionEquals(builtJar, "pkg/Main.class", 52);
+  }
+
+  @IndraFunctionalTest
+  void testKotlinBuild(final TestContext ctx) throws IOException {
+    ctx.copyInput("build.gradle");
+    ctx.copyInput("settings.gradle");
+    ctx.copyInput("src/main/kotlin/pkg/Test.kt");
+
+    ctx.build("build"); // run build
+
+    final Path builtJar = ctx.outputDirectory().resolve("build/libs/kotlin-1.0.0-SNAPSHOT.jar");
+    assertTrue(Files.exists(builtJar));
+    assertBytecodeVersionEquals(builtJar, "pkg/Test.class", 52);
   }
 
   @IndraConfigCacheFunctionalTest

--- a/indra-common/src/test/resources/net/kyori/indra/groovy/in/build.gradle
+++ b/indra-common/src/test/resources/net/kyori/indra/groovy/in/build.gradle
@@ -1,0 +1,19 @@
+plugins {
+  id 'net.kyori.indra'
+  id 'groovy'
+}
+
+group = 'com.example'
+version = '1.0.0-SNAPSHOT'
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  implementation 'org.codehaus.groovy:groovy-all:3.0.9'
+}
+
+tasks.withType(GroovyCompile) {
+  println name
+}

--- a/indra-common/src/test/resources/net/kyori/indra/groovy/in/build.gradle
+++ b/indra-common/src/test/resources/net/kyori/indra/groovy/in/build.gradle
@@ -13,7 +13,3 @@ repositories {
 dependencies {
   implementation 'org.codehaus.groovy:groovy-all:3.0.9'
 }
-
-tasks.withType(GroovyCompile) {
-  println name
-}

--- a/indra-common/src/test/resources/net/kyori/indra/groovy/in/settings.gradle
+++ b/indra-common/src/test/resources/net/kyori/indra/groovy/in/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'groovy'

--- a/indra-common/src/test/resources/net/kyori/indra/groovy/in/src/main/groovy/pkg/Test.groovy
+++ b/indra-common/src/test/resources/net/kyori/indra/groovy/in/src/main/groovy/pkg/Test.groovy
@@ -1,0 +1,10 @@
+package pkg
+
+class Test {
+  def main(String[] args) {
+    args.each {
+      println it
+    }
+    println "Thank you for reading §3.4";
+  }
+}

--- a/indra-common/src/test/resources/net/kyori/indra/kotlinBuild/in/build.gradle
+++ b/indra-common/src/test/resources/net/kyori/indra/kotlinBuild/in/build.gradle
@@ -1,0 +1,11 @@
+plugins {
+  id 'net.kyori.indra'
+  id 'org.jetbrains.kotlin.jvm' version '1.6.10'
+}
+
+group = 'com.example'
+version = '1.0.0-SNAPSHOT'
+
+repositories {
+  mavenCentral()
+}

--- a/indra-common/src/test/resources/net/kyori/indra/kotlinBuild/in/settings.gradle
+++ b/indra-common/src/test/resources/net/kyori/indra/kotlinBuild/in/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'kotlin'

--- a/indra-common/src/test/resources/net/kyori/indra/kotlinBuild/in/src/main/kotlin/pkg/Test.kt
+++ b/indra-common/src/test/resources/net/kyori/indra/kotlinBuild/in/src/main/kotlin/pkg/Test.kt
@@ -1,0 +1,7 @@
+package pkg
+
+class Test(val idea: String) {
+  fun main() {
+    println("Hello, i think $idea")
+  }
+}

--- a/indra-common/src/test/resources/net/kyori/indra/scala/in/build.gradle
+++ b/indra-common/src/test/resources/net/kyori/indra/scala/in/build.gradle
@@ -1,0 +1,15 @@
+plugins {
+  id 'net.kyori.indra'
+  id 'scala'
+}
+
+group = 'com.example'
+version = '1.0.0-SNAPSHOT'
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  implementation 'org.scala-lang:scala-library:2.13.8' // TODO: in newer Gradle versions, test Scala 3?
+}

--- a/indra-common/src/test/resources/net/kyori/indra/scala/in/settings.gradle
+++ b/indra-common/src/test/resources/net/kyori/indra/scala/in/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'scala'

--- a/indra-common/src/test/resources/net/kyori/indra/scala/in/src/main/scala/pkg/Main.scala
+++ b/indra-common/src/test/resources/net/kyori/indra/scala/in/src/main/scala/pkg/Main.scala
@@ -1,0 +1,7 @@
+package pkg
+
+object Main {
+  def main(args: Array[String]) = {
+    println("Thank you for reading §3.4");
+  }
+}

--- a/indra-common/src/test/resources/net/kyori/indra/simpleBuild/in/src/main/java/pkg/Test.java
+++ b/indra-common/src/test/resources/net/kyori/indra/simpleBuild/in/src/main/java/pkg/Test.java
@@ -1,0 +1,7 @@
+package pkg;
+
+public class Test {
+  public static void main(final String[] args) {
+    System.out.print("Thank you for reading §3.4");
+  }
+}


### PR DESCRIPTION
Adds in an extensible system for versioning other JVM languages

This also migrates version handling into the realm of the multirelease plugin, a step on the path to making that a standalone thing

Needs Kotlin integration, but that will probably require classloader hijinks

see GH-40
fixes GH-47
