### PR TITLE
Simplify isRelease check

### DIFF
--- a/indra-common/src/main/java/net/kyori/indra/util/Versioning.java
+++ b/indra-common/src/main/java/net/kyori/indra/util/Versioning.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of indra, licensed under the MIT License.
  *
- * Copyright (c) 2020-2022 KyoriPowered
+ * Copyright (c) 2020-2023 KyoriPowered
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,12 +23,9 @@
  */
 package net.kyori.indra.util;
 
-import net.kyori.indra.git.IndraGitExtension;
-import org.eclipse.jgit.lib.Ref;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Project;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 public final class Versioning {
   public static int versionNumber(final @NotNull JavaVersion version) {
@@ -60,20 +57,13 @@ public final class Versioning {
   /**
    * Verify that this project is checked out to a release version.
    *
-   * <p>This means that:</p>
-   * <ul>
-   * <li>The version does not contain SNAPSHOT</li>
-   * <li>The project is managed within a Git repository</li>
-   * <li>the current head commit is tagged</li>
-   * </ul>
+   * <p>This means that the version does not contain SNAPSHOT</p>
    *
    * @param project the project to check
    * @return if the project is recognized as a release
    */
   public static boolean isRelease(final @NotNull Project project) {
-    final @Nullable IndraGitExtension git = project.getExtensions().findByType(IndraGitExtension.class);
-    final @Nullable Ref tag = git == null ? null : git.headTag();
-    return (tag != null || git == null || !git.isPresent()) && !isSnapshot(project);
+    return !isSnapshot(project);
   }
 
   private Versioning() {

--- a/indra-common/src/test/java/net/kyori/indra/util/VersioningTest.java
+++ b/indra-common/src/test/java/net/kyori/indra/util/VersioningTest.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of indra, licensed under the MIT License.
  *
- * Copyright (c) 2020-2022 KyoriPowered
+ * Copyright (c) 2020-2023 KyoriPowered
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,28 +23,16 @@
  */
 package net.kyori.indra.util;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.stream.Stream;
-import net.kyori.indra.git.GitPlugin;
 import net.kyori.indra.test.IndraTesting;
-import org.eclipse.jgit.api.Git;
-import org.eclipse.jgit.api.errors.GitAPIException;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Project;
-import org.junit.jupiter.api.DynamicNode;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestFactory;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 
 class VersioningTest {
   @Test


### PR DESCRIPTION
This PR removes the requirement for a tag to be present in order to consider a version to be release. This means that it's considered a release when the version doesn't contain `-SNAPSHOT`.

I tried to make the first release of a project since switching to Gradle (+ indra) yesterday and I noticed that the publish step on GitHub Actions just said `publish UP-TO-DATE` and succeeded while having published nothing. After a while of debugging I figured out the cause: in order for something to be counted as a release it the head commit has to have a tag. In hindsight it was described in the wiki, but if snapshots work well you don't expect releases to be any different.

I'm open for suggestions (e.g. making it configurable), but I personally think that removing the requirement makes the most sense. A tag doesn't influence the source code. And if you only want publish things when it has a tag then only run publish when it has a tag (using 'if' e.g. if you're using GitHub Actions.)