### PR TITLE
chore(publishing): configure sigstore signing when publishing via GHA

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ jgit = "7.3.0.+"
 junit = "6.0.0"
 kotlin = "1.9.25"
 mammoth = "1.5.0"
+sigstore = "2.0.0-rc1"
 spotless = "8.0.0"
 
 [libraries]
@@ -33,6 +34,7 @@ asm = { module = "org.ow2.asm:asm", version.ref = "asm" }
 # https://github.com/gradlex-org/jvm-dependency-conflict-resolution/
 jvmDependencyConflictResolution = { module = "org.gradlex:jvm-dependency-conflict-resolution", version = "2.1.2" }
 kotlinPlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+sigstoreSign = { module = "dev.sigstore:sigstore-gradle-sign-plugin", version.ref = "sigstore" }
 
 # git
 
@@ -59,4 +61,4 @@ indra = { id = "net.kyori.indra", version.ref = "indra" }
 indra-spotlessLicenser = { id = "net.kyori.indra.licenser.spotless", version.ref = "indra" }
 indra-pluginPublish = { id = "net.kyori.indra.publishing.gradle-plugin", version.ref = "indra" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
-sigstore = { id = "dev.sigstore.sign", version = "2.0.0-rc1" }
+sigstore = { id = "dev.sigstore.sign", version.ref = "sigstore" }

--- a/indra-common/build.gradle
+++ b/indra-common/build.gradle
@@ -21,6 +21,7 @@ dependencies {
   api project(":indra-git")
   implementation libs.jvmDependencyConflictResolution
   implementation libs.asm
+  implementation libs.sigstoreSign
   api libs.mammoth
   testImplementation project(":indra-testlib")
 

--- a/indra-common/src/main/java/net/kyori/indra/internal/AbstractIndraPublishingPlugin.java
+++ b/indra-common/src/main/java/net/kyori/indra/internal/AbstractIndraPublishingPlugin.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of indra, licensed under the MIT License.
  *
- * Copyright (c) 2020-2023 KyoriPowered
+ * Copyright (c) 2020-2025 KyoriPowered
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -66,6 +66,11 @@ public abstract class AbstractIndraPublishingPlugin implements ProjectPlugin {
     plugins.apply(MavenPublishPlugin.class);
     plugins.apply(SigningPlugin.class);
     plugins.apply(GitPlugin.class);
+
+    final Provider<Boolean> isGhActions = project.getProviders().environmentVariable("GITHUB_ACTIONS").map(Boolean::valueOf).orElse(false);
+    if (isGhActions.get()) {
+      plugins.apply("dev.sigstore.sign");
+    }
 
     final IndraExtensionImpl indra = (IndraExtensionImpl) Indra.extension(extensions);
 


### PR DESCRIPTION
This seems to be the way both plugin portal and Central are moving -- both of them support sigstore bundles, so it seems like we might as well start supporting this.

Not sure how useful it is outside of managed cloud CI, so we only auto-enable on GHA for now.