### PR TITLE
feat(publishing): Put license SPDX id's into project poms rather than long names

### DIFF
--- a/indra-common/src/main/java/net/kyori/indra/internal/AbstractIndraPublishingPlugin.java
+++ b/indra-common/src/main/java/net/kyori/indra/internal/AbstractIndraPublishingPlugin.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of indra, licensed under the MIT License.
  *
- * Copyright (c) 2020-2023 KyoriPowered
+ * Copyright (c) 2020-2025 KyoriPowered
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -94,7 +94,7 @@ public abstract class AbstractIndraPublishingPlugin implements ProjectPlugin {
 
         pom.licenses(licenses -> {
           licenses.license(license -> {
-            license.getName().set(indra.license().map(License::name));
+            license.getName().set(indra.license().map(License::spdx));
             license.getUrl().set(indra.license().map(License::url));
           });
         });


### PR DESCRIPTION
Fixes GH-157