### PR TITLE
feat: add Central Portal publishing plugin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,8 +42,9 @@ jgit = { module = "org.eclipse.jgit:org.eclipse.jgit", version.ref = "jgit" }
 
 gradlePluginPublish = { module = "com.gradle.publish:plugin-publish-plugin", version.ref = "gradlePluginPublish" }
 
-# publishing-sonatype
+# publishing-central and publishing-sonatype
 
+centralPortalPublishing = { module = "dev.lukebemish:central-portal-publishing", version = "0.1.9" }
 nexusPublishPlugin = { module = "io.github.gradle-nexus:publish-plugin", version = "2.0.0" }
 
 # spotless-licenser

--- a/indra-publishing-central/build.gradle
+++ b/indra-publishing-central/build.gradle
@@ -1,0 +1,23 @@
+dependencies {
+  implementation project(":indra-common")
+  implementation libs.centralPortalPublishing
+  testImplementation gradleTestKit()
+}
+
+indra {
+  javaVersions {
+    target 21
+    minimumToolchain 21
+    testWith().set([21, 25])
+  }
+}
+
+indraPluginPublishing {
+  plugin(
+    "indra.publishing.central",
+    "net.kyori.indra.central.IndraCentralPublishingPlugin",
+    "Indra Maven Central Publishing",
+    "Reasonable Maven Central Portal publishing configuration",
+    ["boilerplate", "publishing", "maven-central", "sonatype"]
+  )
+}

--- a/indra-publishing-central/build.gradle
+++ b/indra-publishing-central/build.gradle
@@ -1,7 +1,16 @@
+// Expose the publishing plugin to TestKit without adding it to this plugin's published runtime dependencies.
+configurations {
+  indraPluginTestClasspath
+}
+
 dependencies {
-  implementation project(":indra-common")
   implementation libs.centralPortalPublishing
   testImplementation gradleTestKit()
+  indraPluginTestClasspath project(":indra-common")
+}
+
+tasks.named("pluginUnderTestMetadata") {
+  pluginClasspath.from(configurations.indraPluginTestClasspath)
 }
 
 indra {

--- a/indra-publishing-central/src/main/java/net/kyori/indra/central/IndraCentralPublishingPlugin.java
+++ b/indra-publishing-central/src/main/java/net/kyori/indra/central/IndraCentralPublishingPlugin.java
@@ -26,7 +26,6 @@ package net.kyori.indra.central;
 import dev.lukebemish.centralportalpublishing.CentralPortalProjectExtension;
 import dev.lukebemish.centralportalpublishing.CentralPortalPublishingPlugin;
 import dev.lukebemish.centralportalpublishing.CentralPortalRepositoryHandlerExtension;
-import net.kyori.indra.IndraPublishingPlugin;
 import org.gradle.api.IsolatedAction;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -38,10 +37,11 @@ import org.gradle.api.publish.PublishingExtension;
 /**
  * A settings plugin for configuring publication to Maven Central through the Central Portal.
  *
- * <p>All projects applying {@link IndraPublishingPlugin} automatically contribute their publications to the
- * {@code release} bundle defined on the root project.</p>
+ * <p>All projects applying the {@code net.kyori.indra.publishing} plugin automatically contribute their publications
+ * to the {@code release} bundle defined on the root project.</p>
  */
 public final class IndraCentralPublishingPlugin implements Plugin<Settings> {
+  private static final String INDRA_PUBLISHING_PLUGIN_ID = "net.kyori.indra.publishing";
   private static final String BUNDLE_NAME = "release";
   private static final String ROOT_PROJECT_PATH = ":";
 
@@ -64,7 +64,7 @@ public final class IndraCentralPublishingPlugin implements Plugin<Settings> {
         });
       }
 
-      project.getPlugins().withType(IndraPublishingPlugin.class, plugin -> {
+      project.getPluginManager().withPlugin(INDRA_PUBLISHING_PLUGIN_ID, plugin -> {
         project.getPluginManager().apply(CentralPortalPublishingPlugin.class);
         final PublishingExtension publishing = project.getExtensions().getByType(PublishingExtension.class);
         final ExtensionContainer repositoryExtensions = ((ExtensionAware) publishing.getRepositories()).getExtensions();

--- a/indra-publishing-central/src/main/java/net/kyori/indra/central/IndraCentralPublishingPlugin.java
+++ b/indra-publishing-central/src/main/java/net/kyori/indra/central/IndraCentralPublishingPlugin.java
@@ -1,0 +1,75 @@
+/*
+ * This file is part of indra, licensed under the MIT License.
+ *
+ * Copyright (c) 2026 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.indra.central;
+
+import dev.lukebemish.centralportalpublishing.CentralPortalProjectExtension;
+import dev.lukebemish.centralportalpublishing.CentralPortalPublishingPlugin;
+import dev.lukebemish.centralportalpublishing.CentralPortalRepositoryHandlerExtension;
+import net.kyori.indra.IndraPublishingPlugin;
+import org.gradle.api.IsolatedAction;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.initialization.Settings;
+import org.gradle.api.plugins.ExtensionAware;
+import org.gradle.api.plugins.ExtensionContainer;
+import org.gradle.api.publish.PublishingExtension;
+
+/**
+ * A settings plugin for configuring publication to Maven Central through the Central Portal.
+ *
+ * <p>All projects applying {@link IndraPublishingPlugin} automatically contribute their publications to the
+ * {@code release} bundle defined on the root project.</p>
+ */
+public final class IndraCentralPublishingPlugin implements Plugin<Settings> {
+  private static final String BUNDLE_NAME = "release";
+  private static final String ROOT_PROJECT_PATH = ":";
+
+  @Override
+  public void apply(final Settings settings) {
+    settings.getGradle().getLifecycle().beforeProject(new ConfigureProject());
+  }
+
+  private static final class ConfigureProject implements IsolatedAction<Project> {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void execute(final Project project) {
+      if (ROOT_PROJECT_PATH.equals(project.getPath())) {
+        project.getPluginManager().apply(CentralPortalPublishingPlugin.class);
+        project.getExtensions().getByType(CentralPortalProjectExtension.class).bundle(BUNDLE_NAME, bundle -> {
+          bundle.getUsername().convention(project.getProviders().gradleProperty("sonatypeUsername"));
+          bundle.getPassword().convention(project.getProviders().gradleProperty("sonatypePassword"));
+          bundle.getPublishingType().convention("AUTOMATIC");
+        });
+      }
+
+      project.getPlugins().withType(IndraPublishingPlugin.class, plugin -> {
+        project.getPluginManager().apply(CentralPortalPublishingPlugin.class);
+        final PublishingExtension publishing = project.getExtensions().getByType(PublishingExtension.class);
+        final ExtensionContainer repositoryExtensions = ((ExtensionAware) publishing.getRepositories()).getExtensions();
+        repositoryExtensions.getByType(CentralPortalRepositoryHandlerExtension.class).portalBundle(ROOT_PROJECT_PATH, BUNDLE_NAME);
+      });
+    }
+  }
+}

--- a/indra-publishing-central/src/test/java/net/kyori/indra/central/IndraCentralPublishingPluginTest.java
+++ b/indra-publishing-central/src/test/java/net/kyori/indra/central/IndraCentralPublishingPluginTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import static org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class IndraCentralPublishingPluginTest {
   // IndraPublishingPlugin currently copies coordinates from the root project, which is not compatible with project
@@ -107,7 +108,7 @@ class IndraCentralPublishingPluginTest {
       tasks.register('assertCentralPortalNotConfigured')
       """);
 
-    final BuildResult result = GradleRunner.create()
+    final GradleRunner runner = GradleRunner.create()
       .withProjectDir(projectDirectory.toFile())
       .withPluginClasspath()
       .withArguments(
@@ -115,10 +116,12 @@ class IndraCentralPublishingPluginTest {
         ":other:assertCentralPortalNotConfigured",
         "--configuration-cache",
         "-Dorg.gradle.unsafe.isolated-projects=true"
-      )
-      .build();
+      );
+    final BuildResult result = runner.build();
+    final BuildResult reused = runner.build();
 
     assertEquals(UP_TO_DATE, result.task(":assertCentralPortalConfigured").getOutcome());
     assertEquals(UP_TO_DATE, result.task(":other:assertCentralPortalNotConfigured").getOutcome());
+    assertTrue(reused.getOutput().contains("Configuration cache entry reused."));
   }
 }

--- a/indra-publishing-central/src/test/java/net/kyori/indra/central/IndraCentralPublishingPluginTest.java
+++ b/indra-publishing-central/src/test/java/net/kyori/indra/central/IndraCentralPublishingPluginTest.java
@@ -1,0 +1,124 @@
+/*
+ * This file is part of indra, licensed under the MIT License.
+ *
+ * Copyright (c) 2026 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.indra.central;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class IndraCentralPublishingPluginTest {
+  // IndraPublishingPlugin currently copies coordinates from the root project, which is not compatible with project
+  // isolation. Keep this scoping test separate from the compatibility test below until that behavior is removed.
+  @Test
+  void testConfiguresOnlyIndraPublishingSubproject(final @TempDir Path projectDirectory) throws IOException {
+    Files.writeString(projectDirectory.resolve("settings.gradle"), """
+      plugins {
+        id 'net.kyori.indra.publishing.central'
+      }
+      rootProject.name = 'central-test'
+      include 'sub', 'other'
+      """);
+    Files.writeString(projectDirectory.resolve("build.gradle"), """
+      assert tasks.named('publishReleaseCentralPortalBundle').get().publishingType.get() == 'AUTOMATIC'
+      """);
+    Files.createDirectory(projectDirectory.resolve("sub"));
+    Files.writeString(projectDirectory.resolve("sub/build.gradle"), """
+      group = 'test'
+      version = '1.0.0'
+      description = 'test'
+      apply plugin: 'net.kyori.indra.publishing'
+      assert publishing.repositories.names.contains('centralPortalRelease')
+      tasks.register('assertCentralPortalConfigured')
+      """);
+    Files.createDirectory(projectDirectory.resolve("other"));
+    Files.writeString(projectDirectory.resolve("other/build.gradle"), """
+      plugins {
+        id 'maven-publish'
+      }
+      assert !publishing.repositories.names.contains('centralPortalRelease')
+      tasks.register('assertCentralPortalNotConfigured')
+      """);
+
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(projectDirectory.toFile())
+      .withPluginClasspath()
+      .withArguments(
+        ":sub:assertCentralPortalConfigured",
+        ":other:assertCentralPortalNotConfigured"
+      )
+      .build();
+
+    assertEquals(UP_TO_DATE, result.task(":sub:assertCentralPortalConfigured").getOutcome());
+    assertEquals(UP_TO_DATE, result.task(":other:assertCentralPortalNotConfigured").getOutcome());
+  }
+
+  @Test
+  void testConfigurationCacheAndProjectIsolation(final @TempDir Path projectDirectory) throws IOException {
+    Files.writeString(projectDirectory.resolve("settings.gradle"), """
+      plugins {
+        id 'net.kyori.indra.publishing.central'
+      }
+      rootProject.name = 'central-test'
+      include 'other'
+      """);
+    Files.writeString(projectDirectory.resolve("build.gradle"), """
+      group = 'test'
+      version = '1.0.0'
+      description = 'test'
+      apply plugin: 'net.kyori.indra.publishing'
+      assert publishing.repositories.names.contains('centralPortalRelease')
+      assert tasks.named('publishReleaseCentralPortalBundle').get().publishingType.get() == 'AUTOMATIC'
+      tasks.register('assertCentralPortalConfigured')
+      """);
+    Files.createDirectory(projectDirectory.resolve("other"));
+    Files.writeString(projectDirectory.resolve("other/build.gradle"), """
+      plugins {
+        id 'maven-publish'
+      }
+      assert !publishing.repositories.names.contains('centralPortalRelease')
+      tasks.register('assertCentralPortalNotConfigured')
+      """);
+
+    final BuildResult result = GradleRunner.create()
+      .withProjectDir(projectDirectory.toFile())
+      .withPluginClasspath()
+      .withArguments(
+        ":assertCentralPortalConfigured",
+        ":other:assertCentralPortalNotConfigured",
+        "--configuration-cache",
+        "-Dorg.gradle.unsafe.isolated-projects=true"
+      )
+      .build();
+
+    assertEquals(UP_TO_DATE, result.task(":assertCentralPortalConfigured").getOutcome());
+    assertEquals(UP_TO_DATE, result.task(":other:assertCentralPortalNotConfigured").getOutcome());
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -37,6 +37,7 @@ if (JavaVersion.current() < JavaVersion.toVersion(requiredRuntime)) {
   "indra-common",
   "indra-git",
   "indra-publishing-gradle-plugin",
+  "indra-publishing-central",
   "indra-publishing-sonatype",
   "indra-licenser-spotless",
   "indra-testlib",


### PR DESCRIPTION
Add a settings plugin that creates an automatic Maven Central release bundle and enrolls projects using Indra publishing. Uses https://github.com/lukebemishprojects/CentralPortalPublishing. Keep the legacy Sonatype plugin available so consumers can migrate without a breaking replacement.

Require Java 21 (inherited from centralportalpublishing) and retain compatibility with configuration cache, isolated projects, and composite builds.

closes #211 

## Consumer migration

 ```diff
 // root project build.gradle
 plugins {
-  id "net.kyori.indra.publishing.sonatype"
 }
 ```

 ```diff
 // settings.gradle
 plugins {
+  id "net.kyori.indra.publishing.central" version "<indra-version>"
 }
 ```

 Update release automation:

 ```diff
-./gradlew closeAndReleaseSonatypeStagingRepository
+./gradlew publishReleaseCentralPortalBundle
 ```

 `sonatypeUsername` and `sonatypePassword` remain unchanged, but must contain Central Portal token credentials.

Any project in the build with the Indra publishing plugin applied gets included in the bundle.

 Build runtime requires Java 21 and Gradle 8.14+.
