### PR TITLE
fix(git): Support git worktrees when resolving repositories

### DIFF
--- a/indra-git/src/main/java/net/kyori/indra/git/internal/GitCache.java
+++ b/indra-git/src/main/java/net/kyori/indra/git/internal/GitCache.java
@@ -30,6 +30,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -174,7 +175,8 @@ public class GitCache {
             String line;
             while ((line = reader.readLine()) != null) {
               if (line.startsWith(GITDIR_PREFIX)) {
-                return new File(projectDir.getParentFile(), line.substring(GITDIR_PREFIX.length()).trim());
+                final Path gitDir = projectDir.toPath().resolveSibling(line.substring(GITDIR_PREFIX.length()).trim());
+                return gitDir.toFile();
               }
             }
           }

--- a/indra-git/src/main/java/net/kyori/indra/git/internal/GitCache.java
+++ b/indra-git/src/main/java/net/kyori/indra/git/internal/GitCache.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of indra, licensed under the MIT License.
  *
- * Copyright (c) 2024 KyoriPowered
+ * Copyright (c) 2024-2026 KyoriPowered
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/indra-git/src/test/java/net/kyori/indra/git/IndraGitPluginTest.java
+++ b/indra-git/src/test/java/net/kyori/indra/git/IndraGitPluginTest.java
@@ -136,6 +136,33 @@ class IndraGitPluginTest {
   }
 
   @Test
+  void testRepositoryDetectedInLinkedWorktree() throws IOException, GitAPIException {
+    final Path mainProject = this.projectDir.resolve("main");
+    final Path worktree = this.projectDir.resolve("worktree");
+    Files.createDirectories(mainProject);
+
+    IndraTesting.exec(mainProject, "git", "init", "-b", DEFAULT_BRANCH);
+    try (final Git git = Git.open(mainProject.toFile())) {
+      git.commit()
+        .setAllowEmpty(true)
+        .setMessage("initial commit")
+        .setAuthor(COMMITTER)
+        .setCommitter(COMMITTER)
+        .setSign(false)
+        .call();
+    }
+
+    IndraTesting.exec(mainProject, "git", "worktree", "add", "-b", "worktree-branch", worktree.toString());
+
+    final Project inWorktree = IndraTesting.project(b -> b.withProjectDir(worktree.toFile()));
+    inWorktree.getPluginManager().apply(PLUGIN);
+
+    final IndraGitExtension extension = inWorktree.getExtensions().getByType(IndraGitExtension.class);
+    assertTrue(extension.isPresent());
+    assertEquals("worktree-branch", extension.branchName().get());
+  }
+
+  @Test
   void testHeadTagNullWhenNotCheckedOutToTag() throws IOException, GitAPIException {
     final IndraGitExtensionImpl extension = this.createExtensionAndRepo();
     assertFalse(extension.repositoryValue(QueryHeadTag.Name.class).isPresent());

--- a/indra-git/src/test/java/net/kyori/indra/git/IndraGitPluginTest.java
+++ b/indra-git/src/test/java/net/kyori/indra/git/IndraGitPluginTest.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of indra, licensed under the MIT License.
  *
- * Copyright (c) 2020-2025 KyoriPowered
+ * Copyright (c) 2020-2026 KyoriPowered
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Fixes builds failing with `MissingValueException` on `indraGit.branchName().get()` etc. when the project lives in a `git worktree` checkout.

### Root cause

`GitCache.resolveGit` resolved the `gitdir:` line from a `.git` gitfile with:

```java
new File(projectDir.getParentFile(), line.substring(GITDIR_PREFIX.length()).trim())
```

Linked worktrees write an **absolute** gitdir path (e.g. `gitdir: /path/to/main/.git/worktrees/name`), and on Unix `new File(parent, absoluteChild)` does *not* ignore the parent — it concatenates. The mangled path then made `RepositoryBuilder.setMustExist(true).build()` throw `RepositoryNotFoundException`, which `GitCache` swallowed and reported as "No git repository found".

Submodule gitfiles use relative gitdir paths, which is why that case (covered by the existing `testRepositoryDetectedThroughSubmodule`) always worked.

### Fix

Resolve the gitfile line with `Path#resolveSibling`, which honors absolute paths and resolves relative ones against the gitfile's directory, per `gitrepository-layout`.

### Verification

- New `testRepositoryDetectedInLinkedWorktree` fails on the old code, passes with the fix; full `:indra-git:test` suite (incl. config-cache functional tests) green.
- Reproduced the original failure with Gradle 9.7.0 in a linked worktree and confirmed the fix: `branchName()` / `commit()` now resolve correctly.