### PR TITLE
fix(ci): Only publish releases to the plugin portal

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,9 @@ jobs:
   call-build:
     uses: KyoriPowered/.github/.github/workflows/shared-ci.yaml@trunk
     with:
+      runtime_version: 17
       publish_releases: true
-      gradle_release_publish_tasks: "publish publishPlugins"
+      gradle_release_publish_tasks: "publishPlugins"
     permissions:
       actions: "write"
       contents: "write"


### PR DESCRIPTION
## What

Fix the release publishing configuration in `build.yml`.

## Why

`gradle_release_publish_tasks: "publish publishPlugins"` included a bare `publish` task. For release builds this task is a no-op:

- indra's own build never applies `indra.publishing.sonatype` (it only ships that plugin to other projects), so no release repository is configured (`publishSnapshotsTo("papermc", ...)` is snapshots-only and credential-gated).
- As a result indra has never published to Maven Central — all versions 1.0.1 → 4.0.0 exist only on the Gradle Plugin Portal.

The release publish now runs only `publishPlugins`, matching blossom's configuration. Also passes `runtime_version: 17` explicitly (the shared CI default) for consistency with blossom/mammoth.

> Note: the plugin portal credential chain (shared CI `ORG_GRADLE_PROJECT_pluginPortalApiKey` → indra's extra-property copy) is broken under `com.gradle.plugin-publish` 2.0.0, which resolves credentials via a config-cache `CredentialsValueSource` that does not see extra properties. A separate PR in KyoriPowered/.github exports `GRADLE_PUBLISH_KEY`/`GRADLE_PUBLISH_SECRET` env vars directly.