### PR TITLE
release: prepare for further development on 4.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "net.kyori"
-version = "4.0.1-SNAPSHOT"
+version = "4.1.0-SNAPSHOT"
 description = "KyoriPowered organizational build standards and utilities"
 
 subprojects {


### PR DESCRIPTION
Bump the project version to `4.1.0-SNAPSHOT` to begin development for the 4.1.0 release.

### Verification

- `./gradlew check`