### PR TITLE
release: version 4.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "net.kyori"
-version = "4.1.0-SNAPSHOT"
+version = "4.1.0"
 description = "KyoriPowered organizational build standards and utilities"
 
 def libs = extensions.getByName("libs")


### PR DESCRIPTION
Prepares the repository for the 4.1.0 release by setting the project version to `4.1.0`.

Validation: `./gradlew build`