### PR TITLE
release: prepare for further development on 4.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "net.kyori"
-version = "4.1.0"
+version = "4.1.1-SNAPSHOT"
 description = "KyoriPowered organizational build standards and utilities"
 
 def libs = extensions.getByName("libs")


### PR DESCRIPTION
Prepares for further development after the 4.1.0 release by setting the project version to `4.1.1-SNAPSHOT`.

Validation: `./gradlew build`